### PR TITLE
Merging forked repo with original repo for continuity

### DIFF
--- a/app/Controller/AdminsController.php
+++ b/app/Controller/AdminsController.php
@@ -1,7 +1,12 @@
 <?php
 class AdminsController extends AppController {
   	public $helpers = array('Markdown.Markdown');
-  
+
+/****************************************************************************
+ * ALL ADMINISTRATORS LIST
+ * This creates a list of all NRN admins to be listed in /admins
+ ****************************************************************************
+ */ 
 	public function all($options = null) {
 		if (!$options) {
 			$this->set('admins', $this->Admin->find('all', array('conditions' => array('Admin.active' => true), 'order' => array('Member.full_name'))));
@@ -12,10 +17,23 @@ class AdminsController extends AppController {
 			$this->set('filter', $options);
 		}
 	}
-	
+/****************************************************************************
+ * SEARCH ADMINISTRATOR
+ * When a user clicks the Administrators > Search button in the navbar
+ * (view/elements/nav.ctp), then that triggers the adminSearch function in
+ * irbnet_admin.js. The javascript opens a search console with a plain-text
+ * field.
+ *
+ * This controller function retrieves the content of that search console and
+ * queries the db for first names and last names like that keyword.
+ ****************************************************************************
+ */ 
 	public function search($keyword = null) {
+		// uses implode to return string from array elements
 		$keyword = implode($this->request->data);
+		// queries database for names like the keyword, then passes results into $admins variable
 		$admins = $this->Admin->find('all', array('conditions' => array('OR' => array(array('Admin.first_name LIKE' => '%' . $keyword . '%'), array('Admin.last_name LIKE' => '%' . $keyword . '%')))));
+		// if only one search result found, take the user to the "view" view for that specific admin.
 		if (count($admins) == 1) {
 			$admin = $this->Admin->find('first', array('conditions' => array('OR' => array(array('Admin.first_name LIKE' => '%' . $keyword . '%'), array('Admin.last_name LIKE' => '%' . $keyword . '%')))));
 			return $this->redirect(array('action' => 'view', $admin['Admin']['id']));
@@ -23,7 +41,11 @@ class AdminsController extends AppController {
 			$this->set('admins', $admins);
 		}
 	}
-	
+/****************************************************************************
+ * VIEW ADMINISTRATOR
+ * Allows user to view the admin based on the admin's ID.
+ ****************************************************************************
+ */ 
 	public function view($id = null) {
 		if (!$id) {
 			throw new NotFoundException(__('Invalid administrator'));
@@ -35,8 +57,17 @@ class AdminsController extends AppController {
 		}
 		$this->set('admin', $admin);
 	}
-	
+/****************************************************************************
+ * ADD ADMINISTRATOR
+ * Produces a "New Administrator" form that allows user to add a new
+ * administrator.
+ * 
+ * When the form is submitted, then it passes submission into the database
+ * and brings the user to the view page for that created admin.
+ ****************************************************************************
+ */ 
 	public function add($member = null) {
+		// Uses Member model so that we can populate the Organization dropdown menu
 		$this->loadModel('Member');
 		if (!$member) {
 			$members = $this->Member->find('list', array('fields' => array('Member.id', 'Member.full_name'), 'conditions' => array('Member.active' => 1)));
@@ -55,7 +86,13 @@ class AdminsController extends AppController {
 			$this->Session->setFlash('Unable to save administrator', 'default', array('class' => 'alert alert-danger'));
 		}
 	}
-	
+/****************************************************************************
+ * EDIT ADMINISTRATOR
+ * Produces a "New Administrator" form that allows user to add a new
+ * administrator. This form functions in similar fashion to "add,"
+ * except that it pre-populates and submits based on the admin's id.
+ ****************************************************************************
+ */ 
 	public function edit($id = null) {
 		$this->loadModel('Member');
 		$members = $this->Member->find('list', array('fields' => array('Member.id', 'Member.full_name')));
@@ -83,7 +120,21 @@ class AdminsController extends AppController {
 			$this->request->data = $admin;
 		}
 	}
-	
+/****************************************************************************
+ * RETIRE OR DELETE ADMINISTRATOR
+ * When a user clicks the retire or delete button on the "view" page for a
+ * specific admin, then that triggers the deleteRetire function in
+ * irbnet_admin.js. The javascript opens a div box that asks "are you sure?"
+ * with option to delete or retire the admin.
+ *
+ * The HTML for the div box is described on the "view" View.
+ *
+ * Depending on the link clicked in that div, one of the below functions is
+ * performed.
+ ****************************************************************************
+ */ 
+ 
+ // RETIRE ADMINISTRATOR - marks as inactive
 	public function retire($id) {
 		if($this->request->is('get')) {
 			throw new MethodNotAllowedException();
@@ -92,11 +143,11 @@ class AdminsController extends AppController {
 		$this->Admin->id = $id;
 		if ($this->Admin->save($this->Admin->set(array('active' => 0)))) {
 			$this->Session->setFlash('Administrator retired', 'default', array('class' => 'alert alert-success'));
-			return $this->redirect(array('action' => 'index'));
+			return $this->redirect(array('action' => 'view', $id));
 		}
 		$this->Session->setFlash('Unable to retire administrator', 'default', array('class' => 'alert alert-danger'));
 	}
-	
+ // DELETE ADMINISTRATOR - drops from database
 	public function delete($id) {
 		if ($this->request->is('get')) {
 			throw new MethodNotAllowedException();
@@ -106,5 +157,28 @@ class AdminsController extends AppController {
 			$this->Session->setFlash('Administrator successfully deleted', 'default', array('class' => 'alert alert-success'));
 			return $this->redirect(array('action' => 'all'));
 		}
+	}
+/****************************************************************************
+ * UN-RETIRE ADMINISTRATOR
+ * When a user clicks the retire or delete button on the "view" page for a
+ * specific admin, then that triggers the unRetire function in
+ * irbnet_admin.js. The javascript opens a div box that asks "are you sure?"
+ *
+ * The HTML for the div box is described on the "view" View.
+ ****************************************************************************
+ */ 
+ 
+  // RETIRE ADMINISTRATOR - marks as active
+	public function unretire($id) {
+		if($this->request->is('get')) {
+			throw new MethodNotAllowedException();
+		}
+		
+		$this->Admin->id = $id;
+		if ($this->Admin->save($this->Admin->set(array('active' => 1)))) {
+			$this->Session->setFlash('Administrator un-retired', 'default', array('class' => 'alert alert-success'));
+			return $this->redirect(array('action' => 'view', $id));
+		}
+		$this->Session->setFlash('Unable to un-retire administrator', 'default', array('class' => 'alert alert-danger'));
 	}
 }

--- a/app/Controller/AdminsController.php
+++ b/app/Controller/AdminsController.php
@@ -2,10 +2,9 @@
 class AdminsController extends AppController {
   	public $helpers = array('Markdown.Markdown');
 
-/****************************************************************************
+/**
  * ALL ADMINISTRATORS LIST
  * This creates a list of all NRN admins to be listed in /admins
- ****************************************************************************
  */ 
 	public function all($options = null) {
 		if (!$options) {
@@ -17,7 +16,7 @@ class AdminsController extends AppController {
 			$this->set('filter', $options);
 		}
 	}
-/****************************************************************************
+/**
  * SEARCH ADMINISTRATOR
  * When a user clicks the Administrators > Search button in the navbar
  * (view/elements/nav.ctp), then that triggers the adminSearch function in
@@ -26,7 +25,6 @@ class AdminsController extends AppController {
  *
  * This controller function retrieves the content of that search console and
  * queries the db for first names and last names like that keyword.
- ****************************************************************************
  */ 
 	public function search($keyword = null) {
 		// uses implode to return string from array elements
@@ -41,10 +39,9 @@ class AdminsController extends AppController {
 			$this->set('admins', $admins);
 		}
 	}
-/****************************************************************************
+/**
  * VIEW ADMINISTRATOR
  * Allows user to view the admin based on the admin's ID.
- ****************************************************************************
  */ 
 	public function view($id = null) {
 		if (!$id) {
@@ -57,14 +54,13 @@ class AdminsController extends AppController {
 		}
 		$this->set('admin', $admin);
 	}
-/****************************************************************************
+/**
  * ADD ADMINISTRATOR
  * Produces a "New Administrator" form that allows user to add a new
  * administrator.
  * 
  * When the form is submitted, then it passes submission into the database
  * and brings the user to the view page for that created admin.
- ****************************************************************************
  */ 
 	public function add($member = null) {
 		// Uses Member model so that we can populate the Organization dropdown menu
@@ -86,12 +82,11 @@ class AdminsController extends AppController {
 			$this->Session->setFlash('Unable to save administrator', 'default', array('class' => 'alert alert-danger'));
 		}
 	}
-/****************************************************************************
+/**
  * EDIT ADMINISTRATOR
  * Produces a "New Administrator" form that allows user to add a new
  * administrator. This form functions in similar fashion to "add,"
  * except that it pre-populates and submits based on the admin's id.
- ****************************************************************************
  */ 
 	public function edit($id = null) {
 		$this->loadModel('Member');
@@ -120,7 +115,7 @@ class AdminsController extends AppController {
 			$this->request->data = $admin;
 		}
 	}
-/****************************************************************************
+/**
  * RETIRE OR DELETE ADMINISTRATOR
  * When a user clicks the retire or delete button on the "view" page for a
  * specific admin, then that triggers the deleteRetire function in
@@ -131,7 +126,6 @@ class AdminsController extends AppController {
  *
  * Depending on the link clicked in that div, one of the below functions is
  * performed.
- ****************************************************************************
  */ 
  
  // RETIRE ADMINISTRATOR - marks as inactive
@@ -158,14 +152,13 @@ class AdminsController extends AppController {
 			return $this->redirect(array('action' => 'all'));
 		}
 	}
-/****************************************************************************
+/**
  * UN-RETIRE ADMINISTRATOR
  * When a user clicks the retire or delete button on the "view" page for a
  * specific admin, then that triggers the unRetire function in
  * irbnet_admin.js. The javascript opens a div box that asks "are you sure?"
  *
  * The HTML for the div box is described on the "view" View.
- ****************************************************************************
  */ 
  
   // RETIRE ADMINISTRATOR - marks as active

--- a/app/Controller/CommitteesController.php
+++ b/app/Controller/CommitteesController.php
@@ -1,9 +1,12 @@
 <?php
 class CommitteesController extends AppController {
+/**
+ * 2016-01-25 OB: this controller contains functions that were once used to track committees within a member. 
+ * Committees, however, were not frequently updated, and Zack and I decided to remove committees from the system altogether.
+ */ 
 	public function index() {
 		$this->set('committees', $this->Committee->find('all'));
 	}
-	
 	public function view($id = null) {
 		if (!$id) {
 			throw new NotFoundException(__('Invalid committee'));

--- a/app/Controller/InteractionsController.php
+++ b/app/Controller/InteractionsController.php
@@ -1,5 +1,11 @@
 <?php
 class InteractionsController extends AppController {
+/**
+ * 2016-01-25 OB: this controller contains functions that were once used to track interactions with a staff at a local IRB.
+ * This was largely in response to the discovery that some institutions wouldn't contact Support for months/years. 
+ * Interactions, however, were never updated by Support staff, and was a failed experiment in CRM-style interaction tracking and ticketing.
+ * Zack and I decided to remove committees from the system altogether.
+ */ 
 	public function add($member_id) {
 		$members = $member_id;
 		$this->set(compact('members'));

--- a/app/Controller/LettersController.php
+++ b/app/Controller/LettersController.php
@@ -268,14 +268,15 @@ class LettersController extends AppController {
 		$member_short_name = $letter['Member']['short_name'];
 		$date_received = $letter['Letter']['date_received'];
 		$target_date = $letter['Letter']['target_date'];
+		$type = $letter['Letter']['type'];
 
 		$Email = new CakeEmail('gmail');
 		$Email->from(array('letters@irbnet.org' => 'IRBNet Letter Team'));
 		$Email->to($support_email_address);
-		$Email->subject('Letter Request Completed - ' . $member_short_name);
+		$Email->subject($type . ' Request Completed - ' . $member_short_name);
 		$Email->template('letters_complete');
 		$Email->emailFormat('html');
-		$Email->viewVars(array('user_name' => $user_name, 'member_name' => $member_name, 'date_received' => $date_received, 'target_date' => $target_date));
+		$Email->viewVars(array('user_name' => $user_name, 'member_name' => $member_name, 'date_received' => $date_received, 'target_date' => $target_date, 'type' => $type));
 		$Email->send();
 	}
 

--- a/app/Controller/LettersController.php
+++ b/app/Controller/LettersController.php
@@ -10,9 +10,19 @@ class LettersController extends AppController {
 		$this->Auth->allow('lettersDueToday');
 	}
 
-	public function active()
+	public function active($options = null)
 	{
-		$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.active' => true), 'order' => 'Letter.target_date')));
+		if (!$options) {
+			$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.active' => true), 'order' => 'Letter.target_date')));
+			$this->set('filter_added', false);
+		} else {
+			$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.type' => $options, 'Letter.active' => true), 'order' => array('Letter.target_date'))));
+			//this disables sortable column headers
+			$this->set('filter_added', true);
+			$this->set('filter', $options);
+		}
+		
+		// $this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.active' => true), 'order' => 'Letter.target_date')));
 	}
 	
 	public function history()
@@ -254,5 +264,13 @@ class LettersController extends AppController {
 			endforeach;
 			unset($letter);
 		}
+	}
+	public function all()
+	{
+			$this->set('letters', $this->Letter->find('all', array(
+				'conditions' => array('Letter.type' => 'Stamp'), 
+				'group' => 'Letter.member_id',
+				'order' => 'Member.full_name')
+			));
 	}
 }

--- a/app/Controller/LettersController.php
+++ b/app/Controller/LettersController.php
@@ -9,32 +9,39 @@ class LettersController extends AppController {
 		parent::beforeFilter();
 		$this->Auth->allow('lettersDueToday');
 	}
-
+/**
+ * ACTIVE LETTERS AND STAMPS
+ * Creates a list of active letter and stamp requests.
+ */ 
 	public function active($options = null)
 	{
+		// checks if user is filtering by stamp or letter (type is set as options variable)
 		if (!$options) {
+			// finds all letters where letter is active, order by target date
 			$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.active' => true), 'order' => 'Letter.target_date')));
+			// enables sortable column headers
 			$this->set('filter_added', false);
 		} else {
+			// finds all letters where letter is active AND type matches filter, orders by target date
 			$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.type' => $options, 'Letter.active' => true), 'order' => array('Letter.target_date'))));
-			//this disables sortable column headers
+			// disables sortable column headers
 			$this->set('filter_added', true);
 			$this->set('filter', $options);
 		}
-		
-		// $this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.active' => true), 'order' => 'Letter.target_date')));
 	}
-	
+/**
+ * LETTER AND STAMP REQUEST HISTORY
+ * Displays all of the letter and stamp requests that have ever been created.
+ * Includes search function.
+ */ 
 	public function history()
 	{
     	//allows form to be submitted with no member specified
 		$this->Letter->validate = null;
 		$this->loadModel('Member');
-
 		//this loads member list into dropdown menu
 		$members = $this->Member->find('list', array('fields' => array('Member.id', 'Member.full_name'), 'order' => 'Member.full_name'));
 		$this->set(compact('members'));
-		
 		//if member_id not set at all, user hasn't searched.
 		if ( isset($_GET['member_id']) )
 		{
@@ -59,30 +66,46 @@ class LettersController extends AppController {
 			$this->set('letters', null);
 		}
 	}
-	
+/**
+ * VIEW LETTER OR STAMP REQUEST
+ * Allows user to view the request based on the request's ID.
+ */ 
 	public function view($id = null)
 	{
+		// Checks if id is in get request
 		if (!$id) {
+			// Displays error if no result found
 			throw new NotFoundException(__('Invalid letter request'));
 		}
-		
+		// Finds letter in letter model by id
 		$letter = $this->Letter->findById($id);
+		// Checks if result found
 		if (!$letter) {
+			// Displays error if no result found
 			throw new NotFoundException(__('Invalid letter request'));
 		}
-
+		// Passes in user id
 		$this->set('user_id', CakeSession::read('Auth.User.id'));
+		// Passes in letter data
 		$this->set('letter', $letter);
 	}
-	
+/**
+ * ADD LETTER OR STAMP REQUEST
+ * Allows user to view the request based on the request's ID.
+ */ 
 	public function add()
 	{
+		// loads Member data
 		$this->loadModel('Member');
+		// finds active Members' full names, orders by full names, and stores in variable
 		$members = $this->Member->find('list', array('fields' => array('Member.id', 'Member.full_name'), 'conditions' => array('Member.active' => true), 'order' => 'Member.full_name'));
+		// passes in list of full names as an associative array (by Member ID)
 		$this->set(compact('members'));
-		
+		// checks for form submission via POST
 		if ($this->request->is('post')) {
+			// resets Model data
 			$this->Letter->create();
+			// saves data and check if successful
 			if ($this->Letter->save($this->request->data)) {
 				$this->Session->setFlash('Letter request successfully added', 'default', array('class' => 'alert alert-success'));
 				return $this->redirect(array('action' => 'active'));
@@ -90,35 +113,58 @@ class LettersController extends AppController {
 			$this->Session->setFlash('Unable to add letter request', 'default', array('class' => 'alert alert-danger'));
 		}
 	}
-	
+/**
+ * RETRIEVE AN ADMIN LIST FOR NEW LETTERS AND STAMPS
+ * Gets a list of admins at a specific institution for the "Submitted By" field
+ * when creating a new letter or stamp request.
+ *
+ * This function uses function activateSubmittedByDropdown() in irbnet_admin.js.
+ * The javascript function detects if user selects a member, then sends an AJAX
+ * request to server based on the member id. This function then retrieves the
+ * admins associated with that member id.
+ */ 
 	public function list_admin()
 	{
+		// checks if ajax request
 		if($this->RequestHandler->isAjax()) {
+			// loads admin data
 			$this->loadModel('Admin');
+			// retrieve member id from get request
 			$member_id = $_GET['member_id'];
+			// passes in the member id
 			$this->set('member_id', $member_id);
+			// get a list of active admins at that member
 			$submitters = $this->Admin->find('all', array('conditions' => array('Admin.member_id' => $member_id, 'Admin.active' => true)));
+			// pass in the list as submitter names
 			$this->set('submitter_names', $submitters);
 		} else {
 			$this->redirect(array('action' => 'add'));
 		}
 	}
-	
+/**
+ * EDIT LETTER OR STAMP REQUEST
+ * Allows user to edit the request based on the request's id. 
+ */ 
 	public function edit($id = null)
 	{
+		// if no id in get request, shows error
 		if (!$id) {
 			throw new NotFoundException(__('Invalid letter request'));
 		}
-		
+		// looks up letter by id
 		$letter = $this->Letter->findById($id);
+		// if no result found, shows error
 		if (!$letter) {
 			throw new NotFoundException(__('Invalid letter request'));
 		}
-		
+		// if form submission via post or put, saves form data
 		if ($this->request->is(array('post', 'put'))) {
+			// looks up letter in Model by id
 			$this->Letter->id = $id;
+			// saves form data at db row with that id
 			if ($this->Letter->save($this->request->data)) {
 				$this->Session->setFlash('Letter request successfully updated', 'default', array('class' => 'alert alert-success'));
+				// returns user to view page
 				return $this->redirect(array('action' => 'view', $id));
 			}
 			$this->Session->setFlash('Unable to update letter request', 'default', array('class' => 'alert alert-danger'));
@@ -129,22 +175,31 @@ class LettersController extends AppController {
 			$this->set('letter', $letter);
 		}
 	}
-	
+/**
+ * CLAIM LETTER OR STAMP REQUEST
+ * Marks letter or stamp request as claimed based on request's id.
+ */ 
 	public function claim($id)
 	{
 		if (!$id) {
 			throw new NotFoundException(__('Invalid letter request'));
 		}
-		
+		// get user id from the session info
 		$user_id = CakeSession::read('Auth.User.id');
+		// look up db row by the claim id
 		$this->Letter->id = $id;
+		// save the user id and the claimed date to the db row
 		if ($this->Letter->save($this->Letter->set(array('request_owner' => $user_id, 'claimed_date' => DboSource::expression('NOW()'))))) {
 			$this->Session->setFlash('Letter request claimed', 'default', array('class' => 'alert alert-success'));
+			// take user to active requests queue
 			return $this->redirect(array('action' => 'active'));
 		}
 		$this->Session->setFlash('Unable to claim letter request', 'default', array('class' => 'alert alert-danger'));
 	}
-	
+/**
+ * UNCLAIM LETTER OR STAMP REQUEST
+ * Marks letter or stamp request as claimed based on request's id.
+ */ 
 	public function unclaim($id)
 	{
 		if (!$id) {
@@ -159,7 +214,10 @@ class LettersController extends AppController {
 		}
 		$this->Session->setFlash('Unable to unclaim letter request', 'default', array('class' => 'alert alert-danger'));
 	}
-	
+/**
+ * MARK LETTER OR STAMP REQUEST COMPLETE
+ * Marks letter or stamp request as complete based on request's id.
+ */ 
 	public function complete($id)
 	{
 		if ($this->request->is('get')) {
@@ -186,7 +244,10 @@ class LettersController extends AppController {
 			return $this->redirect(array('action' => 'active'));
 		}
 	}
-	
+/**
+ * LETTER OR STAMP REQUEST COMPLETED EMAIL
+ * Marks letter or stamp request as claimed based on request's id.
+ */ 
 	public function lettersCompleteEmail($letter_id)
 	{
 		App::uses('CakeEmail', 'Network/Email');

--- a/app/Controller/MembersController.php
+++ b/app/Controller/MembersController.php
@@ -144,12 +144,12 @@ class MembersController extends AppController {
             return false;
         }
 		// Retrieve important variables
-        $thisUser_first_name = $this->Session->read('Auth.User.first_name');
+        $thisUser = $this->Session->read('Auth.User.first_name');
         $support_email_address = $support['User']['email_address'];
 		$member_name = $member['Member']['full_name'];
 		// Assemble email and send to Support
 		$Email = new CakeEmail('gmail');
-		$Email->from(array('letters@irbnet.org' => 'IRBNet Letter Team'));
+		$Email->from(array('supportportal@irbnet.org' => 'IRBNet Support Portal'));
 		$Email->to($support_email_address);
 		$Email->subject('Member Retired from Support Portal - ' . $member_name);
 		$Email->template('member_retired');

--- a/app/Controller/MembersController.php
+++ b/app/Controller/MembersController.php
@@ -97,7 +97,7 @@ class MembersController extends AppController {
 		}
 	}
 /****************************************************************************
- * RETIRE OR DELETE MEMBER
+ * RETIRE MEMBER
  * When a user clicks the retire button on the "view" page for a
  * specific member, then that triggers the deleteRetirePopup function in
  * irbnet_admin.js. The javascript opens a div box that asks "are you sure?"
@@ -138,16 +138,16 @@ class MembersController extends AppController {
 		//load Users and find Support Desk account, for email purposes
 		$this->loadModel('User');
         $support = $this->User->find('first', array('conditions' => array('User.username' => 'support')));
-        
+		
         if ($member === false) {
             debug(__METHOD__." failed to retrieve User data for user.id: {$user_id}");
             return false;
         }
-		
-        $thisUser = $this->Session->read('Auth.User.first_name');
+		// Retrieve important variables
+        $thisUser_first_name = $this->Session->read('Auth.User.first_name');
         $support_email_address = $support['User']['email_address'];
 		$member_name = $member['Member']['full_name'];
-
+		// Assemble email and send to Support
 		$Email = new CakeEmail('gmail');
 		$Email->from(array('letters@irbnet.org' => 'IRBNet Letter Team'));
 		$Email->to($support_email_address);

--- a/app/Controller/MembersController.php
+++ b/app/Controller/MembersController.php
@@ -96,7 +96,24 @@ class MembersController extends AppController {
 			$this->request->data = $member;
 		}
 	}
-	
+/****************************************************************************
+ * RETIRE OR DELETE MEMBER
+ * When a user clicks the retire or delete button on the "view" page for a
+ * specific member, then that triggers the deleteRetire function in
+ * irbnet_admin.js. The javascript opens a div box that asks "are you sure?"
+ * with option to delete or retire the member.
+ *
+ * The HTML for the div box is described on the "view" View.
+ *
+ * Retiring a member will also retire the member's administrators and
+ * smart forms.
+ *
+ * Depending on the link clicked in that div, one of the below functions is
+ * performed.
+ ****************************************************************************
+ */ 
+
+// RETIRE MEMBER - marks as inactive
 	public function retire($id)
 	{
 		if ($this->request->is('get')) {
@@ -105,13 +122,17 @@ class MembersController extends AppController {
 		
 		$this->Member->id = $id;
 		if ($this->Member->save($this->Member->set(array('active' => 0)))) {
+			// Retire all administrators for this member id
 			$this->Member->Admin->updateAll(array('Admin.active' => 0), array('Admin.member_id' => $id));
+			// Retire all smart forms for this member id
+			$this->Member->SmartForm->updateAll(array('SmartForm.status' => "'Retired'"), array('SmartForm.member_id' => $id));
+			// Display success message
 			$this->Session->setFlash('Member retired', 'default', array('class' => 'alert alert-success'));
-			return $this->redirect(array('action' => 'index'));
+			return $this->redirect(array('action' => 'view', $id));
 		}
 		$this->Session->setFlash('Unable to retire member', 'default', array('class' => 'alert alert-danger'));
 	}
-	
+// DELETE MEMBER - drops from database
 	public function delete($id)
 	{
 		if ($this->request->is('get')) {
@@ -123,5 +144,28 @@ class MembersController extends AppController {
 			return $this->redirect(array('action' => 'all'));
 		}
 	}
-	
+/****************************************************************************
+ * UN-RETIRE MEMBER
+ * When a user clicks the retire or delete button on the "view" page for a
+ * specific member, then that triggers the unRetire function in
+ * irbnet_admin.js. The javascript opens a div box that asks "are you sure?"
+ *
+ * The HTML for the div box is described on the "view" View.
+ ****************************************************************************
+ */ 
+
+// UN-MEMBER - marks as active
+	public function unretire($id)
+	{
+		if($this->request->is('get')) {
+			throw new MethodNotAllowedException();
+		}
+		
+		$this->Member->id = $id;
+		if ($this->Member->save($this->Member->set(array('active' => 1)))) {
+			$this->Session->setFlash('Member reactivated', 'default', array('class' => 'alert alert-success'));
+			return $this->redirect(array('action' => 'view', $id));
+		}
+		$this->Session->setFlash('Unable to reactivate member', 'default', array('class' => 'alert alert-danger'));
+	}
 }

--- a/app/Controller/SmartFormProjectsController.php
+++ b/app/Controller/SmartFormProjectsController.php
@@ -257,12 +257,12 @@ class SmartFormProjectsController extends AppController {
 		$this->Session->setFlash('Unable to complete smart form project', 'default', array('class' => 'alert alert-danger'));
 	}
 /****************************************************************************
- * PROJECT INVOICE
- * Allows user to create a project invoice based on the information entered
+ * PROJECT SCOPE TEMPLATE
+ * Allows user to create a project scope template based on the information entered
  * for that request.
  ****************************************************************************
  */ 
-    public function invoice($id = null)
+    public function scope($id = null)
     {
         if (!$id) {
             throw new NotFoundException(__('Invalid Smart Form Project'));
@@ -277,7 +277,7 @@ class SmartFormProjectsController extends AppController {
 		$currentYear = date('Y', strtotime($smartFormProject['SmartFormProject']['date_received']));
 		$previousYear = ($currentYear - 1);
 		
-		$this->set('user_id', CakeSession::read('Auth.User.id'));
+		$this->set('thisUser_first_name', CakeSession::read('Auth.User.first_name'));
         $this->set('smartFormProject', $smartFormProject);
         $this->set('currentYear', $currentYear);
 		$this->set('previousYear', $previousYear);

--- a/app/Controller/SmartFormProjectsController.php
+++ b/app/Controller/SmartFormProjectsController.php
@@ -231,7 +231,7 @@ class SmartFormProjectsController extends AppController {
 		$this->Session->setFlash('Unable to unclaim smart form project', 'default', array('class' => 'alert alert-danger'));
 	}
 /****************************************************************************
- * COMPLETE A SMART FORM
+ * COMPLETE A SMART FORM PROJECT
  * Allows user to mark the Smart Form Project as complete.
  ****************************************************************************
  */ 
@@ -256,4 +256,24 @@ class SmartFormProjectsController extends AppController {
 		// Didn't work, show error message.
 		$this->Session->setFlash('Unable to complete smart form project', 'default', array('class' => 'alert alert-danger'));
 	}
+/****************************************************************************
+ * PROJECT INVOICE
+ * Allows user to create a project invoice based on the information entered
+ * for that request.
+ ****************************************************************************
+ */ 
+    public function invoice($id = null)
+    {
+        if (!$id) {
+            throw new NotFoundException(__('Invalid Smart Form Project'));
+        }
+        
+        $smartFormProject = $this->SmartFormProject->findById($id);
+        if (!$smartFormProject) {
+            throw new NotFoundException(__('Invalid Smart Form Project'));
+        }
+
+		$this->set('user_id', CakeSession::read('Auth.User.id'));
+        $this->set('smartFormProject', $smartFormProject);
+    }
 }

--- a/app/Controller/SmartFormProjectsController.php
+++ b/app/Controller/SmartFormProjectsController.php
@@ -176,7 +176,7 @@ class SmartFormProjectsController extends AppController {
             }
             else
             {
-                //this grabs memeber name to display on page
+                //this grabs member name to display on page
                 $member = $this->Member->findById($_GET['member_id']);
                 $this->set('member', $member);
                 
@@ -273,7 +273,32 @@ class SmartFormProjectsController extends AppController {
             throw new NotFoundException(__('Invalid Smart Form Project'));
         }
 
+		// Get current year from the smartFormProject's date received field, then previous year
+		$currentYear = date('Y', strtotime($smartFormProject['SmartFormProject']['date_received']));
+		$previousYear = ($currentYear - 1);
+		
 		$this->set('user_id', CakeSession::read('Auth.User.id'));
         $this->set('smartFormProject', $smartFormProject);
+        $this->set('currentYear', $currentYear);
+		$this->set('previousYear', $previousYear);
+		
+		// Pass in the number of projects that were requested by member in the current year BEFORE this project
+		// 'Current year' is defined as the year in which this request was received
+		$this->set('currentYearProjects', $this->SmartFormProject->find('all', array(
+			'conditions' => array(
+				array('SmartFormProject.member_id' => $smartFormProject['SmartFormProject']['member_id']),
+				array("NOT" => array('SmartFormProject.id' => $id)),
+				array('SmartFormProject.date_received >=' => "$currentYear-01-01", 'SmartFormProject.date_received <=' => $smartFormProject['SmartFormProject']['date_received'])
+			),
+			'order' => array('date_received' => 'asc')
+		)));
+		// Pass in number of projects that were requested in previous year by member
+		$this->set('previousYearProjects', $this->SmartFormProject->find('all', array(
+			'conditions' => array(
+				array('SmartFormProject.member_id' => $smartFormProject['SmartFormProject']['member_id']),
+				array('SmartFormProject.date_received >=' => "$previousYear-01-01", 'SmartFormProject.date_received <=' => "$previousYear-12-31")
+			),
+			'order' => array('date_received' => 'asc')
+		)));
     }
 }

--- a/app/Controller/SmartFormProjectsController.php
+++ b/app/Controller/SmartFormProjectsController.php
@@ -3,13 +3,22 @@ App::uses('DboSource', 'Model/DataSource');
 
 class SmartFormProjectsController extends AppController {
     public $components = array('RequestHandler');
-    
+
+/****************************************************************************
+ * ACTIVE PROJECTS
+ * Creates a list of active smart form projects, used in Wizards tracking.
+ ****************************************************************************
+ */ 
     public function active()
     {
         $this->log('logging data from active controller: ' . print_r($this->request->data, 1));
         $this->set('smartFormProjects', $this->SmartFormProject->find('all', array('conditions' => array('SmartFormProject.active' => true))));
     }
-    
+/****************************************************************************
+ * VIEW PROJECT
+ * Allows user to view the project based on the project's ID.
+ ****************************************************************************
+ */ 
     public function view($id = null)
     {
         if (!$id) {
@@ -24,13 +33,20 @@ class SmartFormProjectsController extends AppController {
 		$this->set('user_id', CakeSession::read('Auth.User.id'));
         $this->set('smartFormProject', $smartFormProject);
     }
-    
+/****************************************************************************
+ * ADD PROJECT
+ * Produces a "New Smart Form Request" form that allows user to add a new
+ * smart form project.
+ ****************************************************************************
+ */ 
     public function add($member_id = null)
     {
+		// Open the user model
         $this->loadModel('User');
+		// Get users who are admins and site admins (i.e. not contractors) to populate "Request Owner" dropdown
         $users = $this->User->find('list', array('fields' => array('User.id', 'User.first_name'), 'order' => 'User.first_name', 'conditions' => array('User.role' => array('site_admin', 'admin'), 'User.active' => true)));
         $this->set(compact('users'));
-                
+        // Populate the FULL list of members
         if ($member_id) {
             $members = $member_id;
             $this->set(compact('members'));            
@@ -39,7 +55,7 @@ class SmartFormProjectsController extends AppController {
             $members = $this->Member->find('list', array('fields' => array('Member.id', 'Member.full_name'), 'conditions' => array('Member.active' => true), 'order' => 'Member.full_name'));
             $this->set(compact('members'));            
         }
-        
+		// When the form is submitted via POST, then send form info to db.
         if ($this->request->is('post')) {
             $this->SmartFormProject->create();
             if ($this->SmartFormProject->save($this->request->data)) {
@@ -49,7 +65,14 @@ class SmartFormProjectsController extends AppController {
             $this->Session->setFlash('Unable to add Smart Form Project', 'default', array('class' => 'alert alert-danger'));
         }
     }
-    
+/****************************************************************************
+ * EDIT PROJECT
+ * Produces a "New Smart Form Request" form that allows user to add a new
+ * smart form project. This form functions in similar fashion to "add,"
+ * except that the view restricts edits on Request Type, Member Name, SF,
+ * and Submitted By.
+ ****************************************************************************
+ */ 
     public function edit($id = null)
     {
         if (!$id) {
@@ -79,7 +102,14 @@ class SmartFormProjectsController extends AppController {
             $this->set('smartFormProject', $smartFormProject);
         }
     }
-
+/****************************************************************************
+ * AJAX JSCRIPT DATA RETRIEVAL
+ * The "Add New Smart Form Project" page uses a javascript function to 
+ * validate data without submitting to the database. To do this, it uses 
+ * irbnet_admin.js "submittedByAndSmartFormsDropdowns()" That js function 
+ * uses the data that is being called here.
+ ****************************************************************************
+ */ 
     public function list_admin_and_forms()
     {
         if ($this->RequestHandler->isAjax()) {
@@ -101,19 +131,29 @@ class SmartFormProjectsController extends AppController {
             $this->redirect(array('action' => 'add'));
         }
     }
-    
+/****************************************************************************
+ * DELETE SMART FORM PROJECT
+ * Allows user to delete a smart form project.
+ ****************************************************************************
+ */ 
 	public function delete($id)
 	{
+		// Only works if request is submitted via POST
 		if ($this->request->is('get')) {
 			throw new MethodNotAllowedException();
 		}
-		
+		// Check to see if it worked.
 		if ($this->SmartFormProject->delete($id)) {
 			$this->Session->setFlash('Project successfully deleted', 'default', array('class' => 'alert alert-success'));
 			return $this->redirect(array('action' => 'active'));
 		}
 	}
-	
+/****************************************************************************
+ * SMART FORM PROJECT HISTORY
+ * Displays all of the smart form projects that have ever been created.
+ * Includes search function.
+ ****************************************************************************
+ */ 
 	public function history()
 	{
     	//allows form to be submitted with no member specified
@@ -148,22 +188,34 @@ class SmartFormProjectsController extends AppController {
 			$this->set('smartFormProjects', null);
 		}    	
 	}
-	
+/****************************************************************************
+ * CLAIM A SMART FORM PROJECT
+ * Allows user to associate Smart Form Project with his/her user id.
+ ****************************************************************************
+ */ 
 	public function claim($id)
 	{
+		// Smart form ID was not valid.
 		if (!$id) {
 			throw new NotFoundException(__('Invalid smart form project'));
 		}
-		
+		// Get user info from session and smart form ID from function argument
 		$user_id = CakeSession::read('Auth.User.id');
 		$this->SmartFormProject->id = $id;
+		// Retrieve timestamp, save to DB along with user id of user.
 		if ($this->SmartFormProject->save($this->SmartFormProject->set(array('user_id' => $user_id, 'claimed_date' => DboSource::expression('NOW()'))))) {
+			// Show success message
 			$this->Session->setFlash('Smart Form project claimed', 'default', array('class' => 'alert alert-success'));
 			return $this->redirect(array('action' => 'active'));
 		}
+		// Didn't work, show error message.
 		$this->Session->setFlash('Unable to claim project', 'default', array('class' => 'alert alert-danger'));
 	}
-	
+/****************************************************************************
+ * UNCLAIM A SMART FORM PROJECT
+ * Allows user to disassociate Smart Form Project with his/her user id.
+ ****************************************************************************
+ */ 
 	public function unclaim($id)
 	{
 		if (!$id) {
@@ -178,20 +230,30 @@ class SmartFormProjectsController extends AppController {
 		}
 		$this->Session->setFlash('Unable to unclaim smart form project', 'default', array('class' => 'alert alert-danger'));
 	}
-	
+/****************************************************************************
+ * COMPLETE A SMART FORM
+ * Allows user to mark the Smart Form Project as complete.
+ ****************************************************************************
+ */ 
 	public function complete($id)
 	{
+		// Must be submitted via POST
 		if ($this->request->is('get')) {
 			throw new MethodNotAllowedException();
 		}
-		
+		// Retrieve Smart Form ID from argument
 		$this->SmartFormProject->id = $id;
+		// Retrieve timestamp, save to DB along with user id of user.
 		if ($this->SmartFormProject->save($this->SmartFormProject->set(array('active' => 0, 'completed_date' => DboSource::expression('NOW()'))))) {
-			//$this->lettersCompleteEmail($id);
+			
+			// Leftover from when Zack converted this from Letters requests. Leaving in place in case we want to send a completion email.
+			// $this->lettersCompleteEmail($id);
+			
+			// Show success message
 			$this->Session->setFlash('Smart Form project completed', 'default', array('class' => 'alert alert-success'));
 			return $this->redirect(array('action' => 'active'));
 		}
+		// Didn't work, show error message.
 		$this->Session->setFlash('Unable to complete smart form project', 'default', array('class' => 'alert alert-danger'));
 	}
-	
 }

--- a/app/Controller/SmartFormProjectsController.php
+++ b/app/Controller/SmartFormProjectsController.php
@@ -4,20 +4,18 @@ App::uses('DboSource', 'Model/DataSource');
 class SmartFormProjectsController extends AppController {
     public $components = array('RequestHandler');
 
-/****************************************************************************
+/**
  * ACTIVE PROJECTS
  * Creates a list of active smart form projects, used in Wizards tracking.
- ****************************************************************************
  */ 
     public function active()
     {
         $this->log('logging data from active controller: ' . print_r($this->request->data, 1));
         $this->set('smartFormProjects', $this->SmartFormProject->find('all', array('conditions' => array('SmartFormProject.active' => true))));
     }
-/****************************************************************************
+/**
  * VIEW PROJECT
  * Allows user to view the project based on the project's ID.
- ****************************************************************************
  */ 
     public function view($id = null)
     {
@@ -33,11 +31,10 @@ class SmartFormProjectsController extends AppController {
 		$this->set('user_id', CakeSession::read('Auth.User.id'));
         $this->set('smartFormProject', $smartFormProject);
     }
-/****************************************************************************
+/**
  * ADD PROJECT
  * Produces a "New Smart Form Request" form that allows user to add a new
  * smart form project.
- ****************************************************************************
  */ 
     public function add($member_id = null)
     {
@@ -65,13 +62,12 @@ class SmartFormProjectsController extends AppController {
             $this->Session->setFlash('Unable to add Smart Form Project', 'default', array('class' => 'alert alert-danger'));
         }
     }
-/****************************************************************************
+/**
  * EDIT PROJECT
  * Produces a "New Smart Form Request" form that allows user to add a new
  * smart form project. This form functions in similar fashion to "add,"
  * except that the view restricts edits on Request Type, Member Name, SF,
  * and Submitted By.
- ****************************************************************************
  */ 
     public function edit($id = null)
     {
@@ -102,13 +98,12 @@ class SmartFormProjectsController extends AppController {
             $this->set('smartFormProject', $smartFormProject);
         }
     }
-/****************************************************************************
+/**
  * AJAX JSCRIPT DATA RETRIEVAL
  * The "Add New Smart Form Project" page uses a javascript function to 
  * validate data without submitting to the database. To do this, it uses 
  * irbnet_admin.js "submittedByAndSmartFormsDropdowns()" That js function 
  * uses the data that is being called here.
- ****************************************************************************
  */ 
     public function list_admin_and_forms()
     {
@@ -131,10 +126,9 @@ class SmartFormProjectsController extends AppController {
             $this->redirect(array('action' => 'add'));
         }
     }
-/****************************************************************************
+/**
  * DELETE SMART FORM PROJECT
  * Allows user to delete a smart form project.
- ****************************************************************************
  */ 
 	public function delete($id)
 	{
@@ -148,11 +142,10 @@ class SmartFormProjectsController extends AppController {
 			return $this->redirect(array('action' => 'active'));
 		}
 	}
-/****************************************************************************
+/**
  * SMART FORM PROJECT HISTORY
  * Displays all of the smart form projects that have ever been created.
  * Includes search function.
- ****************************************************************************
  */ 
 	public function history()
 	{
@@ -188,10 +181,9 @@ class SmartFormProjectsController extends AppController {
 			$this->set('smartFormProjects', null);
 		}    	
 	}
-/****************************************************************************
+/**
  * CLAIM A SMART FORM PROJECT
  * Allows user to associate Smart Form Project with his/her user id.
- ****************************************************************************
  */ 
 	public function claim($id)
 	{
@@ -211,10 +203,9 @@ class SmartFormProjectsController extends AppController {
 		// Didn't work, show error message.
 		$this->Session->setFlash('Unable to claim project', 'default', array('class' => 'alert alert-danger'));
 	}
-/****************************************************************************
+/**
  * UNCLAIM A SMART FORM PROJECT
  * Allows user to disassociate Smart Form Project with his/her user id.
- ****************************************************************************
  */ 
 	public function unclaim($id)
 	{
@@ -230,10 +221,9 @@ class SmartFormProjectsController extends AppController {
 		}
 		$this->Session->setFlash('Unable to unclaim smart form project', 'default', array('class' => 'alert alert-danger'));
 	}
-/****************************************************************************
+/**
  * COMPLETE A SMART FORM PROJECT
  * Allows user to mark the Smart Form Project as complete.
- ****************************************************************************
  */ 
 	public function complete($id)
 	{
@@ -241,12 +231,12 @@ class SmartFormProjectsController extends AppController {
 		if ($this->request->is('get')) {
 			throw new MethodNotAllowedException();
 		}
-		// Retrieve Smart Form ID from argument
+		// Retrieve Smart Form id from argument
 		$this->SmartFormProject->id = $id;
 		// Retrieve timestamp, save to DB along with user id of user.
 		if ($this->SmartFormProject->save($this->SmartFormProject->set(array('active' => 0, 'completed_date' => DboSource::expression('NOW()'))))) {
 			
-			// Leftover from when Zack converted this from Letters requests. Leaving in place in case we want to send a completion email.
+			// 2016019 OB: Leftover from when Zack converted this from Letters requests. Leaving in place in case we want to send a completion email.
 			// $this->lettersCompleteEmail($id);
 			
 			// Show success message
@@ -256,11 +246,10 @@ class SmartFormProjectsController extends AppController {
 		// Didn't work, show error message.
 		$this->Session->setFlash('Unable to complete smart form project', 'default', array('class' => 'alert alert-danger'));
 	}
-/****************************************************************************
+/**
  * PROJECT SCOPE TEMPLATE
  * Allows user to create a project scope template based on the information entered
  * for that request.
- ****************************************************************************
  */ 
     public function scope($id = null)
     {

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -60,7 +60,8 @@ class UsersController extends AppController {
 		$this->set('user', $user);
 		// Create a list of active letter requests that this user is working on.
 		$this->loadModel('Letter');
-		$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.request_owner'=> $user_id, 'Letter.active' => true))));
+		$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.request_owner'=> $user_id, 'Letter.active' => true, 'Letter.type' => 'Letter'))));
+		$this->set('stamps', $this->Letter->find('all', array('conditions' => array('Letter.request_owner'=> $user_id, 'Letter.active' => true, 'Letter.type' => 'Stamp'))));
 		// Create a list of active smart form projects that this user is working on.
 		$this->loadModel('SmartFormProject');
 		$this->set('smartFormProjects',$this->SmartFormProject->find('all',array('conditions' => array('SmartFormProject.user_id'=> $user_id, 'SmartFormProject.active' => true))));

--- a/app/Controller/UsersController.php
+++ b/app/Controller/UsersController.php
@@ -7,7 +7,11 @@ class UsersController extends AppController {
 		parent::beforeFilter();
 		$this->Auth->allow('logout', 'login');
 	}
-
+/****************************************************************************
+ * USER LOG IN
+ * Allows the user to log in and begin a session
+ ****************************************************************************
+ */ 
 	public function login() {
 		if (CakeSession::read('Auth.User.id')) {
 			$this->redirect($this->Auth->redirect());
@@ -23,34 +27,67 @@ class UsersController extends AppController {
 			$this->Session->setFlash('Invalid username or password', 'default', array('class' => 'alert alert-danger'));
 		}
 	}
-	
+/****************************************************************************
+ * THE LOG IN PAGE
+ * Allows the user to log out and end session
+ ****************************************************************************
+ */ 
 	public function logout() {
 		return $this->redirect($this->Auth->logout());
 	}
-	
+/****************************************************************************
+ * THE INDEX (HOME PAGE) FUNCTION
+ * This function grabs data from the model and passes it to the Index in
+ * app\View\Users\Index.ctp.
+ *
+ * 2015-10-28 OB: Commenting out My Member Institutions, My Smart Forms,
+ * and My Enrolling Committees sections (in V and C). "Go-Live" tracking
+ * is no longer implemented in Support Portal, and Wizards are now tracked as
+ * templates (Smart Forms) and requests (Wizard Projects)
+ ****************************************************************************
+ */ 
 	public function index() {
+		// This page is called Home
 		$this->set('title_for_layout', 'Home');
+		// This user's account 
 		if (CakeSession::read('Auth.User.active') == 0) {
 			$this->Session->setFlash('Your account is inactive', 'default', array('class' => 'alert alert-danger'));
 			$this->redirect(array('action' => 'logout'));
 		}
-		
+		// Get the user's name and user ID from the session information, and populate page accordingly.
 		$user_id = CakeSession::read('Auth.User.id');
 		$user = $this->User->findById($user_id);
 		$this->set('user', $user);
-		$this->loadModel('Member');
-		$this->set('members', $this->Member->find('all', array('conditions' => array('Member.specialist' => $user_id))));
-		$this->loadModel('SmartForm');
-		$this->set('smartForms', $this->SmartForm->find('all', array('conditions' => array('SmartForm.developer' => $user_id, 'SmartForm.status' => 'In Development'), 'order' => 'SmartForm.launch_date')));
-		$enrolling_committees = array();
-		for($i = 0; $i < count($user['Committee']); $i++) {
-			if($user['Committee'][$i]['status'] == 'Enrolling') {
-				array_push($enrolling_committees, $this->Member->find('all', array('conditions' => array('Member.id' => $user['Committee'][$i]['member_id']))));
-			}
-		}
-		$this->set('enrolling_committees', $enrolling_committees);
+		// Create a list of active letter requests that this user is working on.
+		$this->loadModel('Letter');
+		$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.request_owner'=> $user_id, 'Letter.active' => true))));
+		// Create a list of active smart form projects that this user is working on.
+		$this->loadModel('SmartFormProject');
+		$this->set('smartFormProjects',$this->SmartFormProject->find('all',array('conditions' => array('SmartFormProject.user_id'=> $user_id, 'SmartFormProject.active' => true))));
+
+		// Create a list of members where this user is listed as the member specialist (REMOVED)
+		// $this->loadModel('Member');
+		// this->set('members', $this->Member->find('all', array('conditions' => array('Member.specialist' => $user_id))));
+		// Create a list of Smart Forms in which user is listed as Wizard Developer (REMOVED)
+		// $this->loadModel('SmartForm');
+		// $this->set('smartForms', $this->SmartForm->find('all', array('conditions' => array('SmartForm.developer' => $user_id, 'SmartForm.status' => 'In Development'), 'order' => 'SmartForm.launch_date')));
+		// Create a list of Enrolling Committees in which user is listed as Enrollment Specialist (REMOVED)
+		// $enrolling_committees = array();
+		// for($i = 0; $i < count($user['Committee']); $i++) {
+		// 	if($user['Committee'][$i]['status'] == 'Enrolling') {
+		// 		array_push($enrolling_committees, $this->Member->find('all', array('conditions' => array('Member.id' => $user['Committee'][$i]['member_id']))));
+		// 	}
+		// }
+		// $this->set('enrolling_committees', $enrolling_committees);
+
 	}
 	
+/****************************************************************************
+ * THE MASTER USERS LIST
+ * This users list provides info on the user's role, privileges, status, and
+ * last log-in. It is available to site admins ONLY.
+ ****************************************************************************
+ */ 
 	public function all() {
 		$user_role = CakeSession::read('Auth.User.role');
 		if ($user_role != 'site_admin') {
@@ -58,28 +95,43 @@ class UsersController extends AppController {
 		}
 		$this->set('users', $this->User->find('all'));
 	}
-	
+
+/****************************************************************************
+ * THE USER PROFILE
+ * Allows the user to view their own specific account info.
+ ****************************************************************************
+ */ 
 	public function view($id = null) {
+		// Grab this user's information from Session.
 		$user_role = CakeSession::read('Auth.User.role');
 		$user_id = CakeSession::read('Auth.User.id');
+		// This page is called the User Profile
 		$this->set('title_for_layout', 'User Profile');
+		// Check for permissions.
 		if (($user_role != 'site_admin') && ($user_id != $id)) {
-			throw new MethodNotAllowedException(__('Unable to access this page'));
+			throw new ForbiddenException(__('Unable to access this page'));
 		}
-		
+		// Check if User exists.
 		$this->User->id = $id;
 		if (!$this->User->exists()) {
 			throw new NotFoundException(__('Invalid user.'));
 		}
+		// Send user data to User Profile page.
 		$this->set('user', $this->User->read(null, $id));
 	}
-	
+/****************************************************************************
+ * ADD NEW USER
+ * Allows SITE ADMINS ONLY to add new users to the Support Portal
+ ****************************************************************************
+ */ 
 	public function add() {
+		// Grab this user's information from Session.
 		$user_role = CakeSession::read('Auth.User.role');
+		// Check for permissions.
 		if ($user_role != 'site_admin') {
-			throw new MethodNotAllowedException(__('Unable to access this page'));
+			throw new ForbiddenException(__('Unable to access this page'));
 		}
-		
+		// When user submits form via POST, take form and add to db
 		if ($this->request->is('post')) {
 			$this->User->create();
 			if ($this->User->save($this->request->data)) {
@@ -89,21 +141,29 @@ class UsersController extends AppController {
 			$this->Session->setFlash('Unable to save new user', 'default', array('class' => 'alert alert-danger'));
 		}
 	}
-	
+/****************************************************************************
+ * EDIT USER INFO
+ * Allows user details to be edited by SITE ADMINS (all) and USERS (specific)
+ ****************************************************************************
+ */ 
 	public function edit($id = null) {
+		// Grab this user's information from Session.
 		$this->User->id = $id;
 		$user_id = CakeSession::read('Auth.User.id');
 		$user_role = CakeSession::read('Auth.User.role');
+		// This page is called the Edit Profile
 		$this->set('title_for_layout', 'Edit Profile');
+		// Check for permissions
 		if (($user_role != 'site_admin') && ($user_id != $id)) {
-			throw new MethodNotAllowedException(__('Unable to access this page'));
+			throw new ForbiddenException(__('Unable to access this page'));
 		}
-		
+		// If user details not found, throw error
 		if (!$this->User->exists()) {
 			throw new NotFoundException(__('Invalid user.'));
 		}
-		
+		// When user submits form via POST or PUT, take form and add to db
 		if ($this->request->is('post') || $this->request->is('put')) {
+			// Check if successful.
 			if ($this->User->save($this->request->data)) {
 				$this->Session->setFlash('Your profile has been updated', 'default', array('class' => 'alert alert-success'));
 				return $this->redirect(array('action' => 'view', $id));
@@ -114,7 +174,11 @@ class UsersController extends AppController {
 			unset($this->request->data['User']['password']);
 		}
 	}
-	
+/****************************************************************************
+ * EDIT USER PASSWORD
+ * Allows user password to be edited by SITE ADMINS (all) and USERS (specific)
+ ****************************************************************************
+ */ 
 	public function password($id = null) {
 		$this->User->id = $id;
 		$user_id = CakeSession::read('Auth.User.id');
@@ -138,7 +202,11 @@ class UsersController extends AppController {
 			unset($this->request->data['User']['password']);
 		}
 	}
-	
+/****************************************************************************
+ * ACTIVATE USER
+ * Allows users to be reactivated if they have been deactivated.
+ ****************************************************************************
+ */ 
 	public function activate($id) {
 		if ($this->request->is('get')) {
 			throw new MethodNotAllowedException();
@@ -152,7 +220,11 @@ class UsersController extends AppController {
 		$this->Session->setFlash(__('Unable to activate user'));
 		$this->Session->setFlash('Invalid username or password', 'default', array('class' => 'alert alert-danger'));
 	}
-	
+/****************************************************************************
+ * ACTIVATE USER
+ * Allows users to be deactivated if they are active.
+ ****************************************************************************
+ */ 
 	public function inactivate($id) {
 		if ($this->request->is('get')) {
 			throw new MethodNotAllowedException();
@@ -165,7 +237,12 @@ class UsersController extends AppController {
 		}
 		$this->Session->setFlash('Unable to inactivate user', 'default', array('class' => 'alert alert-danger'));
 	}
-	
+/****************************************************************************
+ * DELETE USER
+ * Allows users to be deleted if they have been deactivated. Has not been
+ * implemented in view.
+ ****************************************************************************
+ */ 
 	public function delete($id = null) {
 		$this->request->onlyAllow('post');
 		

--- a/app/Model/Letter.php
+++ b/app/Model/Letter.php
@@ -21,6 +21,9 @@ class Letter extends AppModel {
 		'submitter' => array(
 			'rule' => 'notEmpty'
 		),
+		'type' => array(
+    		'rule' => 'notEmpty'
+		),
 		'new_templates' => array(
 			'rule' => 'numeric',
 			'notEmpty' => true,

--- a/app/Model/Member.php
+++ b/app/Model/Member.php
@@ -1,6 +1,25 @@
 <?php
 class Member extends AppModel {
-	public $hasMany = array('Admin', 'Committee', 'Letter', 'SmartForm', 'Interaction', 'SmartFormProject');
+	public $hasMany = array(
+		'Admin' => array(
+			'dependent'=>true
+		), 
+		'Committee' => array(
+			'dependent'=>true
+		),
+		'Letter' => array(
+			'dependent'=>true
+		), 
+		'SmartForm' => array(
+			'dependent'=>true
+		),
+		'Interaction' => array(
+			'dependent'=>true
+		),
+		'SmartFormProject' => array(
+			'dependent'=>true
+		)
+	);
 	public $belongsTo = array(
 		'User' => array(
 			'className' => 'User',

--- a/app/View/Admins/search.ctp
+++ b/app/View/Admins/search.ctp
@@ -1,4 +1,4 @@
-<h2 class='title'>National Research Network Admnistrators</h2>
+<h2 class='title'>National Research Network Administrators</h2>
 <h4 class='sub-title'>Search</h4>
 
 <p>&nbsp;</p>

--- a/app/View/Admins/view.ctp
+++ b/app/View/Admins/view.ctp
@@ -1,5 +1,9 @@
 <h2><?php echo h($admin['Admin']['first_name']) . ' ' . h($admin['Admin']['last_name']) . ($admin['Admin']['active'] ? null : ' - RETIRED'); ?></h2>
-<h4><?php echo $this->Html->link("<span class='glyphicon glyphicon-pencil action-image' aria-hidden='true'></span>", array('action' => 'edit', $admin['Admin']['id']), array('escapeTitle' => false)); ?>&nbsp;&nbsp;&nbsp;<a href="#" id="deleteRetireLink"><span class='glyphicon glyphicon-remove action-image' aria-hidden='true'></span></a></h4>
+<h4>
+	<?php echo $this->Html->link("<span class='glyphicon glyphicon-pencil action-image' aria-hidden='true'></span>", array('action' => 'edit', $admin['Admin']['id']), array('escapeTitle' => false)); ?>
+	&nbsp;&nbsp;&nbsp;
+	<?php echo ($admin['Admin']['active'] ? "<a href='#' id='deleteRetireLink'><span class='glyphicon glyphicon-remove action-image' aria-hidden='true'></span></a>" : "<a href='#' id='unRetireLink'><span class='glyphicon glyphicon-repeat action-image' aria-hidden='true'></span></a>"); ?>
+</h4>
 <p>&nbsp;</p>
 <div>
 	<h4>Details:</h4>
@@ -28,10 +32,18 @@
 	<p>&nbsp;</p>
 
 
-<!-- Delete / Retire Member Popup -->
-<div id="deleteRetirePopup" title="Delete / Retire Member">
+<!-- Delete / Retire Administrator Popup -->
+<div id="deleteRetirePopup" title="Retire / Delete Administrator">
 	<p>Would you like to retire this administrator (because they have left their organization / role), or delete them altogether?</p>
 	<h6>Please note that deleting an administrator cannot be undone.</h6>
 	<p>&nbsp;</p>
 	<p><?php echo $this->Form->postLink('Retire', array('action' => 'retire', $admin['Admin']['id']));?> | <?php echo $this->Form->postLink('Delete', array('action' => 'delete', $admin['Admin']['id']));?></p>
+</div>
+
+<!-- Un-Retire Administrator Popup -->
+<div id="unRetirePopup" title="Reactivate Administrator">
+	<p>Would you like to reactivate this administrator and return them to active status?</p>
+	<p>This will place them back in the pool of active administrators for <?php echo $admin['Member']['full_name']; ?>.</p>
+	<p>&nbsp;</p>
+	<p><?php echo $this->Form->postLink('Reactivate', array('action' => 'unretire', $admin['Admin']['id']));?></p>
 </div>

--- a/app/View/Elements/nav.ctp
+++ b/app/View/Elements/nav.ctp
@@ -15,15 +15,15 @@
       Wizards <span class="caret"></span>
     </a>
     <ul class="dropdown-menu" role="menu">
-      <li role="presentation" class="dropdown-header">Letters</li>
-			<li><?php echo $this->Html->link('Letter Queue', array('controller' => 'letters', 'action' => 'active')); ?></li>
-      <li><?php echo $this->Html->link('New Letter Request', array('controller' => 'letters', 'action' => 'add')); ?></li>
-      <li><?php echo $this->Html->link('Letter Request History', array('controller' => 'letters', 'action' => 'history')); ?></li>
+      <li role="presentation" class="dropdown-header">Letters and Stamps</li>
+		  <li><?php echo $this->Html->link('Letter and Stamp Queue', array('controller' => 'letters', 'action' => 'active')); ?></li>
+		  <li><?php echo $this->Html->link('New Letter or Stamp Request', array('controller' => 'letters', 'action' => 'add')); ?></li>
+		  <li><?php echo $this->Html->link('Letter and Stamp Request History', array('controller' => 'letters', 'action' => 'history')); ?></li>
       <li role="presentation" class="dropdown-header">Smart Forms</li>
-      <li><?php echo $this->Html->link('All Smart Forms', array('controller' => 'smartForms', 'action' => 'index')); ?></li>
-      <li><?php echo $this->Html->link('Active Smart Form Projects', array('controller' => 'smartFormProjects', 'action' => 'active')); ?></li>
-      <li><?php echo $this->Html->link('New Smart Form Project', array('controller' => 'smartFormProjects', 'action' => 'add')); ?></li>
-      <li><?php echo $this->Html->link('Smart Form Project History', array('controller' => 'smartFormProjects', 'action' => 'history')); ?></li>
+		  <li><?php echo $this->Html->link('All Smart Forms', array('controller' => 'smartForms', 'action' => 'index')); ?></li>
+		  <li><?php echo $this->Html->link('Active Smart Form Projects', array('controller' => 'smartFormProjects', 'action' => 'active')); ?></li>
+		  <li><?php echo $this->Html->link('New Smart Form Project', array('controller' => 'smartFormProjects', 'action' => 'add')); ?></li>
+		  <li><?php echo $this->Html->link('Smart Form Project History', array('controller' => 'smartFormProjects', 'action' => 'history')); ?></li>
     </ul>
   </li>
 
@@ -76,6 +76,7 @@
     <ul class="dropdown-menu" role="menu">
 			<li><?php echo $this->Html->link('CITI Integration', array('controller' => 'members', 'action' => 'all', 'citi_integration')); ?></li>
 			<li><?php echo $this->Html->link('WIRB Integration', array('controller' => 'members', 'action' => 'all', 'wirb_integration')); ?></li>
+			<li><?php echo $this->Html->link('Stamping Tools', array('controller' => 'letters', 'action' => 'all')); ?></li>			
 			<li><?php echo $this->Html->link('Single Sign-On', array('controller' => 'members', 'action' => 'all', 'sso')); ?></li>
 			<li><?php echo $this->Html->link('File Access', array('controller' => 'members', 'action' => 'all', 'file_access')); ?></li>
 			<li><?php echo $this->Html->link('Contract Leads', array('controller' => 'admins', 'action' => 'all', 'contract_lead')); ?></li>

--- a/app/View/Emails/html/letters_complete.ctp
+++ b/app/View/Emails/html/letters_complete.ctp
@@ -1,6 +1,6 @@
 <p>Support,</p>
 
-<p><?php echo $user_name; ?> has completed the following letter request:</p>
+<p><?php echo $user_name; ?> has completed the following <?php echo $type; ?> request:</p>
 
 <p>Member: <?php echo $member_name; ?></p>
 

--- a/app/View/Emails/html/member_retired.ctp
+++ b/app/View/Emails/html/member_retired.ctp
@@ -1,9 +1,9 @@
 <p>Support,</p>
 
-<p><?php echo $thisUser; ?> has retired the following Member from the Support Portal:</p>
+<p><?php echo $thisUser_first_name; ?> has retired the following Member from the Support Portal:</p>
 
 <p>Member: <?php echo $member_name; ?></p>
 
-<p>If this is incorrect, please go to the following link and click the "undo" button:</p>
+<p>If this was unintentional, please go to the following link and click the "undo" button. Administrators and smart forms will have to be marked as active as well:</p>
 
 <p><a href="http://www.irbnetresources.org/supportportal/members/view/<?php echo $member_id; ?>" target="_blank">http://www.irbnetresources.org/supportportal/members/view/<?php echo $member_id; ?></a></p>

--- a/app/View/Emails/html/member_retired.ctp
+++ b/app/View/Emails/html/member_retired.ctp
@@ -1,6 +1,6 @@
 <p>Support,</p>
 
-<p><?php echo $thisUser_first_name; ?> has retired the following Member from the Support Portal:</p>
+<p><?php echo $thisUser; ?> has retired the following Member from the Support Portal:</p>
 
 <p>Member: <?php echo $member_name; ?></p>
 

--- a/app/View/Emails/html/member_retired.ctp
+++ b/app/View/Emails/html/member_retired.ctp
@@ -1,0 +1,9 @@
+<p>Support,</p>
+
+<p><?php echo $thisUser; ?> has retired the following Member from the Support Portal:</p>
+
+<p>Member: <?php echo $member_name; ?></p>
+
+<p>If this is incorrect, please go to the following link and click the "undo" button:</p>
+
+<p><a href="http://www.irbnetresources.org/supportportal/members/view/<?php echo $member_id; ?>" target="_blank">http://www.irbnetresources.org/supportportal/members/view/<?php echo $member_id; ?></a></p>

--- a/app/View/Layouts/default.ctp
+++ b/app/View/Layouts/default.ctp
@@ -56,7 +56,7 @@ $cakeDescription = __d('cake_dev', 'IRBNet Support Portal');
 					</form>
 				</div>
 
-				<div id="adminSearchBox" class="searchBox" title="Search for an Organization">
+				<div id="adminSearchBox" class="searchBox" title="Search for an Administrator">
 					<p>Enter first or last name:<p>
 					<form method="post" action="<?php echo Router::url(array('controller' => 'admins', 'action' => 'search')); ?>">
 						<input type="text" id="searchAdminName" name="searchAdminName" size="30">

--- a/app/View/Layouts/default.ctp
+++ b/app/View/Layouts/default.ctp
@@ -68,7 +68,7 @@ $cakeDescription = __d('cake_dev', 'IRBNet Support Portal');
 
 		<div id="footer" class="container">
 			<div>
-				<p>Copyright &copy; 2002-2015 Research Dataware, LLC.&nbsp;&nbsp;&nbsp;All Rights Reserved.</p>
+				<p>Copyright &copy; 2002-<?php echo date("Y"); ?> Research Dataware, LLC.&nbsp;&nbsp;&nbsp;All Rights Reserved.</p>
 			</div>
 		</div>
 	</div>

--- a/app/View/Layouts/faq_layout.ctp
+++ b/app/View/Layouts/faq_layout.ctp
@@ -52,7 +52,7 @@
                     </div>
                     <p>&nbsp;</p>
                     <div id="footer">
-                        <p>Copyright &copy; 2002-2015 Research Dataware, LLC.&nbsp;&nbsp;&nbsp;All Rights Reserved.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</p>
+                        <p>Copyright &copy; 2002-<?php echo date("Y"); ?> Research Dataware, LLC.&nbsp;&nbsp;&nbsp;All Rights Reserved.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</p>
                     </div>
                 </div>
             </div>

--- a/app/View/Letters/active.ctp
+++ b/app/View/Letters/active.ctp
@@ -1,4 +1,4 @@
-<h2 class="title">Letter Request Queue</h1>
+<h2 class="title">Letter and Stamp Request Queue</h1>
 
 <p></span>&nbsp;</p>
 
@@ -7,6 +7,7 @@
 		<tr>
 			<th>Target Date</th>
 			<th>Member</th>
+			<th>Type</th>
 			<th>New</th>
 			<th>Revised</th>
 			<th>Enrollment</th>
@@ -21,13 +22,14 @@
 		<tr>
 			<td><?php echo $letter['Letter']['target_date']; ?></td>
 			<td><?php echo $letter['Member']['short_name']; ?></td>
+			<td><?php echo $letter['Letter']['type']; ?></td>
 			<td><?php echo $letter['Letter']['new_templates']; ?></td>
 			<td><?php echo $letter['Letter']['revised_templates']; ?></td>
 			<td><?php echo ($letter['Letter']['enrollment'] == 1 ? 'Yes' : 'No'); ?></td>
 			<td><?php echo (!$letter['Letter']['request_owner'] ? $this->Html->link('[claim]', array('controller' => 'letters', 'action' => 'claim', $letter['Letter']['id']), array('confirm' => 'Are you sure you want to claim this letter request?')) : $letter['User']['first_name']); ?></td>
-			<td><?php echo $this->Form->postLink("<span class='glyphicon glyphicon-ok action-image' aria-hidden='true'></span>", array('controller' => 'letters', 'action' => 'complete', $letter['Letter']['id']), array('escapeTitle' => false, 'confirm' => 'Are you sure you want to complete this letter request?')); ?></td>
+			<td><?php echo $this->Form->postLink("<span class='glyphicon glyphicon-ok action-image' aria-hidden='true'></span>", array('controller' => 'letters', 'action' => 'complete', $letter['Letter']['id']), array('escapeTitle' => false, 'confirm' => 'Are you sure you want to complete this letter or stamp request?')); ?></td>
 			<td><?php echo $this->Html->link("<span class='glyphicon glyphicon-search action-image' aria-hidden='true'></span>", array('controller' => 'letters', 'action' => 'view', $letter['Letter']['id']), array('escapeTitle' => false)); ?></td>
-			<td><?php echo $this->Form->postLink("<span class='glyphicon glyphicon-remove action-image' aria-hidden='true'></span>", array('controller' => 'letters', 'action' => 'delete', $letter['Letter']['id']), array('escapeTitle' => false, 'confirm' => 'Are you sure you want to Delete this letter request? If needed, you can edit it by clicking the View icon.')); ?></td>
+			<td><?php echo $this->Form->postLink("<span class='glyphicon glyphicon-remove action-image' aria-hidden='true'></span>", array('controller' => 'letters', 'action' => 'delete', $letter['Letter']['id']), array('escapeTitle' => false, 'confirm' => 'Are you sure you want to delete this letter or stamp request? If needed, you can edit it by clicking the View icon.')); ?></td>
 		</tr>
 		<?php endforeach; ?>
 		<?php unset($letter); 

--- a/app/View/Letters/add.ctp
+++ b/app/View/Letters/add.ctp
@@ -1,4 +1,4 @@
-<h2 class="title">New Letter Request</h2>
+<h2 class="title">New Letter or Stamp Request</h2>
 
 <p>&nbsp;</p>
 
@@ -21,6 +21,21 @@
 			<label class="col-sm-4 control-label">Request Submitted By:</label>
 			<div class="col-sm-5" id="submitter_name">
 				<?php echo $this->Form->input('submitter', array('label' => false, 'disabled' => 'disabled', 'class' => 'form-control')); ?>
+			</div>
+		</div>
+		
+		<div class="form-group" id="submitter_name_holder">
+			<label class="col-sm-4 control-label">Request Type:</label>
+			<div class="col-sm-5" id="submitter_name">
+				<?php echo $this->Form->input('type', array(
+					'label' => false,
+					'class' => 'form-control',
+					'options' => array(
+						'Letter' => 'Letter',
+						'Stamp' => 'Stamp',
+					),
+					'empty' => ''
+				)); ?>
 			</div>
 		</div>
 		

--- a/app/View/Letters/all.ctp
+++ b/app/View/Letters/all.ctp
@@ -1,0 +1,32 @@
+<h2 class="title">National Research Network Members</h2>
+<h4 class="sub-title">Stamping Tools</h4>
+
+
+<p>&nbsp;</p>
+
+<div class="col-sm-8 col-sm-offset-2">
+	<table class="table table-condensed table-bordered table-hover">
+		<thead>
+			<tr>
+				<th>Member Name</th>
+				<th>Short Name</th>
+				<th>ID</th>
+			</tr>
+		</thead>
+		
+		<tbody>
+			<?php if ($letters == null) { ?>
+			<tr><td colspan="3">No members to display</td></tr>
+			<?php } else {
+				foreach ($letters as $letter): ?>
+			<tr class="list-item">
+				<td><?php echo $this->Html->link($letter['Member']['full_name'], array('action' => 'view', $letter['Member']['id'])); ?></td>
+				<td><?php echo $letter['Member']['short_name']; ?></td>
+				<td><?php echo $letter['Member']['op_num']; ?></td>
+			</tr>
+			<?php endforeach; ?>
+			<?php unset($letter); 
+			} ?>
+		</tbody>
+	</table>
+</div>

--- a/app/View/Letters/edit.ctp
+++ b/app/View/Letters/edit.ctp
@@ -1,4 +1,4 @@
-<h2 class="title">Edit Letter Request</h2>
+<h2 class="title">Edit Letter or Stamp Request</h2>
 
 <p>&nbsp;</p>
 
@@ -14,6 +14,21 @@
 			<label class="col-sm-4 control-label">Request Submitted By:</label>
 			<div class="col-sm-5" id="submitter_name">
 				<?php echo $this->Form->input('submitter_placeHolder', array('label' => false, 'default' => (is_numeric($letter['Letter']['submitter']) ? ($letter['Admin']['first_name'] . ' ' . $letter['Admin']['last_name']) : h($letter['Letter']['submitter'])), 'disabled' => 'disabled', 'class' => 'form-control')); ?>
+			</div>
+		</div>
+		<div class="form-group" id="submitter_name_holder">
+			<label class="col-sm-4 control-label">Request Type:</label>
+			<div class="col-sm-5" id="submitter_name">
+				<?php echo $this->Form->input('type', array(
+					'default' => $letter['Letter']['type'],
+					'label' => false,
+					'class' => 'form-control',
+					'options' => array(
+						'Letter' => 'Letter',
+						'Stamp' => 'Stamp',
+					),
+					'empty' => ''
+				)); ?>
 			</div>
 		</div>
 		<div class="form-group">

--- a/app/View/Letters/history.ctp
+++ b/app/View/Letters/history.ctp
@@ -1,4 +1,4 @@
-<h2 class="title">IRBNet Letter Requests</h2>
+<h2 class="title">IRBNet Letter and Stamp Requests</h2>
 <p>&nbsp;</p>
 <div class="col-sm-4 col-sm-offset-4 text-center">
 	<h4>Requests by Member:</h4>
@@ -27,8 +27,9 @@
 			<th><?php echo $this->Html->link('Date Received', array('action' => 'history', '?' => array('member_id' => $_GET['member_id'], 's' => 'date_received'))); ?></th>
 			<th><?php echo $this->Html->link('Date Completed', array('action' => 'history', '?' => array('member_id' => $_GET['member_id'], 's' => 'completed_date'))); ?></th>
 			<?php echo ($_GET['member_id'] == null ? '<th>Member</th>' : '<th>Submitter</th>'); ?>
-			<th><?php echo $this->Html->link('New Letters', array('action' => 'history', '?' => array('member_id' => $_GET['member_id'], 's' => 'new_templates', 'o' => 'desc'))); ?></th>
-			<th><?php echo $this->Html->link('Revised Letters', array('action' => 'history', '?' => array('member_id' => $_GET['member_id'], 's' => 'revised_templates', 'o' => 'desc'))); ?></th>
+			<th>Type</th>
+			<th><?php echo $this->Html->link('New Templates', array('action' => 'history', '?' => array('member_id' => $_GET['member_id'], 's' => 'new_templates', 'o' => 'desc'))); ?></th>
+			<th><?php echo $this->Html->link('Revised Templates', array('action' => 'history', '?' => array('member_id' => $_GET['member_id'], 's' => 'revised_templates', 'o' => 'desc'))); ?></th>
 			<th>Enrollment?</th>
 			<th><?php echo $this->Html->link('Owner', array('action' => 'history', '?' => array('member_id' => $_GET['member_id'], 's' => 'request_owner'))); ?></th>
 			<th colspan="2">Actions</th>
@@ -38,6 +39,7 @@
 			<td><?php echo $letter['Letter']['date_received']; ?></td>
 			<td><?php echo ($letter['Letter']['completed_date'] ? date("Y-m-d", strtotime($letter['Letter']['completed_date'])) : '<em>Active</em>'); ?></td>
 			<td><?php echo ($_GET['member_id'] == null ? $letter['Member']['short_name'] : ((is_numeric($letter['Letter']['submitter']) ? ($letter['Admin']['first_name'] . ' ' . $letter['Admin']['last_name']) : h($letter['Letter']['submitter'])))); ?></td>
+			<td><?php echo $letter['Letter']['type']; ?></td>
 			<td><?php echo $letter['Letter']['new_templates']; ?></td>
 			<td><?php echo $letter['Letter']['revised_templates']; ?></td>
 			<td><?php echo ($letter['Letter']['enrollment'] ? 'Yes' : 'No'); ?></td>

--- a/app/View/Letters/view.ctp
+++ b/app/View/Letters/view.ctp
@@ -1,9 +1,10 @@
-<h3>Letter Request</h3>
+<h3>Letter or Stamp Request</h3>
 
 <p>&nbsp;</p>
 
 <h4><?php echo h($letter['Member']['full_name']); ?></h4>
 <p>Submitted By: <strong><?php echo (is_numeric($letter['Letter']['submitter']) ? ($letter['Admin']['first_name'] . ' ' . $letter['Admin']['last_name']) : h($letter['Letter']['submitter'])); ?></strong></p>
+<p>Type: <strong><?php echo $letter['Letter']['type']; ?></strong></p>
 <p>New Templates: <strong><?php echo $letter['Letter']['new_templates']; ?></strong></p>
 <p>Revised Templates: <strong><?php echo $letter['Letter']['revised_templates']; ?></strong></p>
 <p>Enrollment? <strong><?php echo ($letter['Letter']['enrollment'] ? 'Yes' : 'No'); ?></strong></p>

--- a/app/View/Members/all.ctp
+++ b/app/View/Members/all.ctp
@@ -34,11 +34,11 @@
 				<th>Member Name</th>
 				<th>Short Name</th>
 				<th>ID</th>
-			<? } else { ?>
+			<?php } else { ?>
 				<th><?php echo $this->Html->link('Member Name', array('action' => 'all', '?' => array('order' => 'full_name'))); ?></th>
 				<th><?php echo $this->Html->link('Short Name', array('action' => 'all', '?' => array('order' => 'short_name'))); ?></th>
 				<th><?php echo $this->Html->link('ID', array('action' => 'all', '?' => array('order' => 'op_num'))) ?></th>
-			<? } ?>
+			<?php } ?>
 			</tr>
 		</thead>
 		

--- a/app/View/Members/view.ctp
+++ b/app/View/Members/view.ctp
@@ -38,6 +38,12 @@ if($admins) {
 	<h4><?php echo $this->Html->link("<span class='glyphicon glyphicon-pencil action-image' aria-hidden='true'></span>", array('action' => 'edit', $member['Member']['id']), array('escapeTitle' => false)); ?>
 	&nbsp;&nbsp;&nbsp;
 	<?php echo ($member['Member']['active'] ? "<a href='#' id='deleteRetireLink'><span class='glyphicon glyphicon-remove action-image' aria-hidden='true'></span></a>" : "<a href='#' id='unRetireLink'><span class='glyphicon glyphicon-repeat action-image' aria-hidden='true'></span></a>"); ?>
+	<?php
+		// If Member was recently created, or if this user is Site Admin, then allow Member to be deleted.
+		if (($this->Time->wasWithinLast("21 days", $member['Member']['created'])) || ($this->Session->read('Auth.User.role') == 'site_admin')) {
+			echo "&nbsp;&nbsp;&nbsp;<a href='#' id='deleteLink'><span class='glyphicon glyphicon-trash action-image' aria-hidden='true'></span></a>";
+		}
+	?>
 	
 	<p>&nbsp;</p>
 	
@@ -224,15 +230,23 @@ if($admins) {
 	</table>
 </div>
 
-<!-- Delete / Retire Member Popup -->
-<div id="deleteRetirePopup" title="Retire / Delete Member">
-	<p><strong><em>IMPORTANT! Please read this warning!</em></strong></p>
-	<p>You are about to delete or retire a member institution from the Support Portal. Only retire the member if the institution no longer uses IRBNet. Only delete the member if this record should not exist in the database.</p>
-	<p>Would you like to retire this member (because they have left IRBNet), or delete them altogether?</p>
+<!-- Retire Member Popup -->
+<div id="deleteRetirePopup" title="Retire Member">
+	<p>You are about to retire a member institution from the Support Portal. Only retire the member if the institution no longer uses IRBNet.</p>
 	<p>If you retire a member, then all corresponding administrators and smart forms will be retired as well.</p>
 	<h6>Please note that deleting a member cannot be undone.</h6>
 	<p>&nbsp;</p>
-	<p><?php echo $this->Form->postLink('Retire', array('controller' => 'members', 'action' => 'retire', $member['Member']['id']), array('class' => 'postLink-link'));?> | <?php echo $this->Form->postLink('Delete', array('controller' => 'members', 'action' => 'delete', $member['Member']['id']));?></p>
+	<p><?php echo $this->Form->postLink('Retire', array('controller' => 'members', 'action' => 'retire', $member['Member']['id']), array('class' => 'postLink-link'));?></p>
+</div>
+
+<!-- Delete Member Popup -->
+<div id="deletePopup" title="Delete Member">
+	<p><strong><em>Important!</em></strong></p>
+	<p>You are about to delete a member institution from the Support Portal!</p>
+	<p>If you delete a member, then all corresponding administrators, smart forms, smart form projects, letters, and interactions will be deleted as well.</p>
+	<h6>Please note that deleting a member cannot be undone.</h6>
+	<p>&nbsp;</p>
+	<p><?php echo $this->Form->postLink('Delete', array('controller' => 'members', 'action' => 'delete', $member['Member']['id']));?></p>
 </div>
 
 

--- a/app/View/Members/view.ctp
+++ b/app/View/Members/view.ctp
@@ -105,13 +105,16 @@ if($admins) {
 				?>
 				</tbody>
 			</table>
+		<?php endif; ?>
+			<p><?php echo $this->Html->link('Add Administrator', array('controller' => 'admins', 'action' => 'add', $member['Member']['id'])); ?></p>
+		<?php if ($retired_admins): ?>
+			<p>&nbsp;</p>
 			<p>Retired administrators: <?php echo $retired_admins ?>
 			<?php echo ($retired_admins > 0) ? "<p><a href='#' id='retiredAdminsLink'>Click here</a> to see the list.</p>" : null; ?></p>
 			<?php
 					unset($admin);
-				endif;
 			?>
-			<p><?php echo $this->Html->link('Add Administrator', array('controller' => 'admins', 'action' => 'add', $member['Member']['id'])); ?></p>
+		<?php endif; ?>
 	</div>
 
 	<!-- buffer div -->

--- a/app/View/Members/view.ctp
+++ b/app/View/Members/view.ctp
@@ -35,7 +35,9 @@ if($admins) {
 
 <div>
 	<h2><?php echo h($member['Member']['full_name']) . ($member['Member']['active'] ? null : ' - RETIRED'); ?></h2>
-	<h4><?php echo $this->Html->link("<span class='glyphicon glyphicon-pencil action-image' aria-hidden='true'></span>", array('action' => 'edit', $member['Member']['id']), array('escapeTitle' => false)); ?>&nbsp;&nbsp;&nbsp;<a href="#" id="deleteRetireLink"><span class='glyphicon glyphicon-remove action-image' aria-hidden='true'></span></a></h4>
+	<h4><?php echo $this->Html->link("<span class='glyphicon glyphicon-pencil action-image' aria-hidden='true'></span>", array('action' => 'edit', $member['Member']['id']), array('escapeTitle' => false)); ?>
+	&nbsp;&nbsp;&nbsp;
+	<?php echo ($member['Member']['active'] ? "<a href='#' id='deleteRetireLink'><span class='glyphicon glyphicon-remove action-image' aria-hidden='true'></span></a>" : "<a href='#' id='unRetireLink'><span class='glyphicon glyphicon-repeat action-image' aria-hidden='true'></span></a>"); ?>
 	
 	<p>&nbsp;</p>
 	
@@ -223,11 +225,21 @@ if($admins) {
 </div>
 
 <!-- Delete / Retire Member Popup -->
-<div id="deleteRetirePopup" title="Delete / Retire Member">
+<div id="deleteRetirePopup" title="Retire / Delete Member">
+	<p><strong><em>IMPORTANT! Please read this warning!</em></strong></p>
+	<p>You are about to delete or retire a member institution from the Support Portal. Only retire the member if the institution no longer uses IRBNet. Only delete the member if this record should not exist in the database.</p>
 	<p>Would you like to retire this member (because they have left IRBNet), or delete them altogether?</p>
+	<p>If you retire a member, then all corresponding administrators and smart forms will be retired as well.</p>
 	<h6>Please note that deleting a member cannot be undone.</h6>
 	<p>&nbsp;</p>
 	<p><?php echo $this->Form->postLink('Retire', array('controller' => 'members', 'action' => 'retire', $member['Member']['id']), array('class' => 'postLink-link'));?> | <?php echo $this->Form->postLink('Delete', array('controller' => 'members', 'action' => 'delete', $member['Member']['id']));?></p>
 </div>
 
 
+<!-- Un-Retire Member Popup -->
+<div id="unRetirePopup" title="Reactivate Member">
+	<p>Would you like to reactivate this member and return them to active status?</p>
+	<h6>Please note that reactivating a member does not reactivate their smart forms and administrators.</h6>
+	<p>&nbsp;</p>
+	<p><?php echo $this->Form->postLink('Reactivate', array('action' => 'unretire', $member['Member']['id']));?></p>
+</div>

--- a/app/View/SmartFormProjects/active.ctp
+++ b/app/View/SmartFormProjects/active.ctp
@@ -47,7 +47,7 @@
 			<td><?php echo (!$smartFormProject['SmartFormProject']['user_id'] ? $this->Html->link('[claim]', array('action' => 'claim', $smartFormProject['SmartFormProject']['id']), array('confirm' => 'Are you sure you want to claim this project?')) : $smartFormProject['User']['first_name']); ?></td>
 			<td><?php echo $this->Form->postLink("<span class='glyphicon glyphicon-ok action-image' aria-hidden='true'></span>", array('action' => 'complete', $smartFormProject['SmartFormProject']['id']), array('escapeTitle' => false, 'confirm' => 'Are you sure you want to complete this project?')); ?></td>
 			<td><?php echo $this->Html->link("<span class='glyphicon glyphicon-search action-image' aria-hidden='true'></span>", array('action' => 'view', $smartFormProject['SmartFormProject']['id']), array('escapeTitle' => false)); ?></td>
-			<td><?php echo $this->Html->link("<span class='glyphicon glyphicon-envelope action-image' aria-hidden='true'></span>", array('action' => 'invoice', $smartFormProject['SmartFormProject']['id']), array('escapeTitle' => false)); ?></td>
+			<td><?php echo $this->Html->link("<span class='glyphicon glyphicon-envelope action-image' aria-hidden='true'></span>", array('action' => 'scope', $smartFormProject['SmartFormProject']['id']), array('escapeTitle' => false)); ?></td>
 			<td><?php echo $this->Form->postLink("<span class='glyphicon glyphicon-remove action-image' aria-hidden='true'></span>", array('action' => 'delete', $smartFormProject['SmartFormProject']['id']), array('escapeTitle' => false, 'confirm' => 'Are you sure you want to Delete this project? If needed, you can edit it by clicking the View icon.')); ?></td>
 		</tr>
 		<?php

--- a/app/View/SmartFormProjects/active.ctp
+++ b/app/View/SmartFormProjects/active.ctp
@@ -12,7 +12,7 @@
 			<th>Target Date</th>
 			<th>Output Change</th>
 			<th>Owner</th>
-			<th colspan="3">Actions</th>
+			<th colspan="4">Actions</th>
 		</tr>
 		
 		<?php
@@ -47,6 +47,7 @@
 			<td><?php echo (!$smartFormProject['SmartFormProject']['user_id'] ? $this->Html->link('[claim]', array('action' => 'claim', $smartFormProject['SmartFormProject']['id']), array('confirm' => 'Are you sure you want to claim this project?')) : $smartFormProject['User']['first_name']); ?></td>
 			<td><?php echo $this->Form->postLink("<span class='glyphicon glyphicon-ok action-image' aria-hidden='true'></span>", array('action' => 'complete', $smartFormProject['SmartFormProject']['id']), array('escapeTitle' => false, 'confirm' => 'Are you sure you want to complete this project?')); ?></td>
 			<td><?php echo $this->Html->link("<span class='glyphicon glyphicon-search action-image' aria-hidden='true'></span>", array('action' => 'view', $smartFormProject['SmartFormProject']['id']), array('escapeTitle' => false)); ?></td>
+			<td><?php echo $this->Html->link("<span class='glyphicon glyphicon-envelope action-image' aria-hidden='true'></span>", array('action' => 'invoice', $smartFormProject['SmartFormProject']['id']), array('escapeTitle' => false)); ?></td>
 			<td><?php echo $this->Form->postLink("<span class='glyphicon glyphicon-remove action-image' aria-hidden='true'></span>", array('action' => 'delete', $smartFormProject['SmartFormProject']['id']), array('escapeTitle' => false, 'confirm' => 'Are you sure you want to Delete this project? If needed, you can edit it by clicking the View icon.')); ?></td>
 		</tr>
 		<?php

--- a/app/View/SmartFormProjects/add.ctp
+++ b/app/View/SmartFormProjects/add.ctp
@@ -31,10 +31,14 @@
             <label class="col-sm-4 control-label">Member Name:</label>
             <div class="col-sm-5">
                 <select class="form-control" id="member-placeholder" disabled="disabled"></select>
-                <?php echo $this->Form->input('member_id', array('label' => false, 'empty' => '', 'id' => 'member_name', 'class' => 'collapse form-control', 'onchange' => 'submittedByAndSmartFormsDropdowns()')); ?>
+                <?php
+				// This function references a function "submittedByAndSmartFormsDropdowns" that is located in irbnet_admin.js in app\webroot\js.
+				// In this line, function checks if any smart forms exist for this member. If no, then it returns an error message. If yes,
+				// then the function populates "smart_form_name" and "submitter_name" with the names of each smart form and the admin.
+				echo $this->Form->input('member_id', array('label' => false, 'empty' => '', 'id' => 'member_name', 'class' => 'collapse form-control', 'onchange' => 'submittedByAndSmartFormsDropdowns()')); ?>
             </div>
         </div>
-        
+
         <div id="ajax-dropdown-container">
             <div class="form-group" id="smart_form_holder">
                 <label class="col-sm-4 control-label">Smart Form:</label>

--- a/app/View/SmartFormProjects/invoice.ctp
+++ b/app/View/SmartFormProjects/invoice.ctp
@@ -1,0 +1,70 @@
+<h3>Smart Form Invoice</h3>
+
+<p>
+&nbsp;
+</p>
+
+<h4>Instructions</h4>
+
+<p>
+<?php echo $this->Session->read('Auth.User.first_name'); ?>, please copy this template into the Wizards inbox and complete as needed. Thanks!
+</p>
+
+<p>
+&nbsp;
+</p>
+
+<h4>Invoice Template</h4>
+
+<p>
+In response to the recent <?php echo $smartFormProject['SmartFormProject']['type']; ?> Request to <?php echo $smartFormProject['Member']['full_name'] ?>'s <strong><?php echo $smartFormProject['SmartForm']['name']; ?></strong>, please note the enclosed scope and revised fee schedule.
+</p>
+
+<p>
+To approve this <?php echo $smartFormProject['SmartFormProject']['type']; ?> Request, please request that <?php echo $smartFormProject['Admin']['first_name']; ?> respond to this email with confirmation and any invoicing instructions for our team. Wizards are scheduled and processed in the order they are received. [(<em>Delete this section as needed</em>) Please note that fees have been waived for this request.]
+</p>
+
+<p>
+Please contact me directly with any questions.
+</p>
+
+<p>
+&#42;&#42;&#42;&#42;&#42;&#42;&#42;
+</p>
+
+<p>
+<strong>Date Requested:</strong> <?php echo $smartFormProject['SmartFormProject']['date_received']; ?>
+</p>
+
+<p>
+<strong>Institution:</strong> <?php echo $smartFormProject['Member']['full_name'] ?>
+</p>
+
+<p>
+<strong>Requested By:</strong> <?php echo $smartFormProject['Admin']['first_name']; ?> <?php echo $smartFormProject['Admin']['last_name']; ?> (email: <a href="mailto:<?php echo $smartFormProject['Admin']['email_address']; ?>"><?php echo $smartFormProject['Admin']['email_address']; ?></a>)
+</p>
+
+<p>
+<strong>Summary of Requested Changes:</strong><br />
+<?php echo $smartFormProject['SmartFormProject']['comments']; ?>
+</p>
+
+<p>
+<strong>Project Scope:</strong> <?php echo $smartFormProject['SmartFormProject']['scope']; ?><br />
+<strong>Output Change:</strong> <?php echo ($smartFormProject['SmartFormProject']['output_change'] ? 'Yes' : 'No'); ?>
+<!-- For future release, include list of previous projects submitted for this form in previous two years -->
+</p>
+
+
+<p>
+<strong>Total Cost of Requested Changes:</strong> [<em>TO DO</em>]<br />
+* Due at time of acceptance:</strong> [<em>TO DO</em>]
+</p>
+
+<p>
+* Due on anniversary of this date:</strong> [<em>TO DO</em>]<br />
+   ** Data maintenance fee:</strong> [<em>TO DO</em>]<br />
+</p>
+
+<p>&nbsp;</p>
+<p><?php echo $this->Html->link('Back', array('action' => 'view', $smartFormProject['SmartFormProject']['id'])); ?></p>

--- a/app/View/SmartFormProjects/invoice.ctp
+++ b/app/View/SmartFormProjects/invoice.ctp
@@ -7,7 +7,7 @@
 <h4>Instructions</h4>
 
 <p>
-<?php echo $this->Session->read('Auth.User.first_name'); ?>, please copy this template into the Wizards inbox and complete as needed. Thanks!
+<?php echo $this->Session->read('Auth.User.first_name'); ?>, please copy this template into the Wizards inbox, edit it, and send it to Andy if necessary. Thanks!
 </p>
 
 <p>
@@ -65,6 +65,39 @@ Please contact me directly with any questions.
 * Due on anniversary of this date:</strong> [<em>TO DO</em>]<br />
    ** Data maintenance fee:</strong> [<em>TO DO</em>]<br />
 </p>
+
+<p>
+<strong>Previous Requests:</strong><br />
+<?php echo $currentYear; ?>
+	<ul>
+        <?php 
+		if (!$currentYearProjects) { ?>
+			<li>There were no previous projects requested in <?php echo $currentYear; ?></li>
+		<?php } ?>
+		<?php foreach($currentYearProjects as $currentYearProject): ?>
+						<li><?php echo $currentYearProject['SmartFormProject']['scope'] . ' request submitted by ' . $currentYearProject['Admin']['first_name'] . ' ' . $currentYearProject['Admin']['last_name'] . ' on ' . $currentYearProject['SmartFormProject']['date_received'] ?></li>
+		<?php
+			endforeach;
+			unset($currentYearProject);
+		?>
+	</ul>
+
+
+<?php echo $previousYear; ?>
+	<ul>
+        <?php 
+		if (!$previousYearProjects) { ?>
+			<li>There were no projects requested in <?php echo $previousYear; ?></li>
+		<?php } ?>
+		<?php foreach($previousYearProjects as $previousYearProject): ?>
+						<li><?php echo $previousYearProject['SmartFormProject']['scope'] . ' request submitted by ' . $previousYearProject['Admin']['first_name'] . ' ' . $previousYearProject['Admin']['last_name'] . ' on ' . $previousYearProject['SmartFormProject']['date_received'] ?></li>
+		<?php
+			endforeach;
+			unset($previousYearProject);
+		?>
+	</ul>
+</p>
+
 
 <p>&nbsp;</p>
 <p><?php echo $this->Html->link('Back', array('action' => 'view', $smartFormProject['SmartFormProject']['id'])); ?></p>

--- a/app/View/SmartFormProjects/invoice.ctp
+++ b/app/View/SmartFormProjects/invoice.ctp
@@ -7,7 +7,11 @@
 <h4>Instructions</h4>
 
 <p>
-<?php echo $this->Session->read('Auth.User.first_name'); ?>, please copy this template into the Wizards inbox, edit it, and send it to Andy if necessary. Thanks!
+This page is intended to help you quickly create a template letter that you can send off to Andy for authorization. When you need to send an invoice to Andy, please copy this template into your message.
+</p>
+
+<p>
+Please note: when this page describes "previous requests," it is looking for requests in which the "Date Requested" field is the same as or earlier than the "Date Requested" field for this request.
 </p>
 
 <p>
@@ -52,7 +56,6 @@ Please contact me directly with any questions.
 <p>
 <strong>Project Scope:</strong> <?php echo $smartFormProject['SmartFormProject']['scope']; ?><br />
 <strong>Output Change:</strong> <?php echo ($smartFormProject['SmartFormProject']['output_change'] ? 'Yes' : 'No'); ?>
-<!-- For future release, include list of previous projects submitted for this form in previous two years -->
 </p>
 
 

--- a/app/View/SmartFormProjects/scope.ctp
+++ b/app/View/SmartFormProjects/scope.ctp
@@ -1,4 +1,4 @@
-<h3>Smart Form Invoice</h3>
+<h3>Smart Form Scope</h3>
 
 <p>
 &nbsp;
@@ -7,7 +7,7 @@
 <h4>Instructions</h4>
 
 <p>
-This page is intended to help you quickly create a template letter that you can send off to Andy for authorization. When you need to send an invoice to Andy, please copy this template into your message.
+This page is intended to help you quickly create a template letter that you can send off to Andy for authorization. When you need to send a scope to Andy, please copy this template into your message and edit the message to include the tallies of new steps, revised steps, new fillins, and revised fillins.
 </p>
 
 <p>
@@ -18,7 +18,7 @@ Please note: when this page describes "previous requests," it is looking for req
 &nbsp;
 </p>
 
-<h4>Invoice Template</h4>
+<h4>Scope Template</h4>
 
 <p>
 In response to the recent <?php echo $smartFormProject['SmartFormProject']['type']; ?> Request to <?php echo $smartFormProject['Member']['full_name'] ?>'s <strong><?php echo $smartFormProject['SmartForm']['name']; ?></strong>, please note the enclosed scope and revised fee schedule.
@@ -58,15 +58,20 @@ Please contact me directly with any questions.
 <strong>Output Change:</strong> <?php echo ($smartFormProject['SmartFormProject']['output_change'] ? 'Yes' : 'No'); ?>
 </p>
 
+<p>
+Number of New Steps: [<em><?php echo strtoupper($thisUser_first_name) ?>: TO DO</em>]<br />
+Number of Revised Steps: [<em><?php echo strtoupper($thisUser_first_name) ?>: TO DO</em>]<br />
+Number of New Fillins: [<em><?php echo strtoupper($thisUser_first_name) ?>: TO DO</em>]<br />
+Number of Revised Fillins: [<em><?php echo strtoupper($thisUser_first_name) ?>: TO DO</em>]<br />
 
 <p>
-<strong>Total Cost of Requested Changes:</strong> [<em>TO DO</em>]<br />
-* Due at time of acceptance:</strong> [<em>TO DO</em>]
+<strong>Total Cost of Requested Changes:</strong> [<em>ANDY: TO DO</em>]<br />
+* Due at time of acceptance:</strong> [<em>ANDY: TO DO</em>]
 </p>
 
 <p>
-* Due on anniversary of this date:</strong> [<em>TO DO</em>]<br />
-   ** Data maintenance fee:</strong> [<em>TO DO</em>]<br />
+* Due on anniversary of this date:</strong> [<em>ANDY: TO DO</em>]<br />
+   ** Data maintenance fee:</strong> [<em>ANDY: TO DO</em>]<br />
 </p>
 
 <p>

--- a/app/View/SmartFormProjects/view.ctp
+++ b/app/View/SmartFormProjects/view.ctp
@@ -13,5 +13,5 @@
 <p class="claim_link">Project Owned By: <?php echo (!$smartFormProject['SmartFormProject']['user_id'] ? $this->Html->link('[claim]', array('action' => 'claim', $smartFormProject['SmartFormProject']['id'])) : '<strong>' . $smartFormProject['User']['first_name'] . '</strong>'); ?> <?php echo ($smartFormProject['SmartFormProject']['user_id'] == $user_id ? $this->Html->link('[unclaim]', array('action' => 'unclaim', $smartFormProject['SmartFormProject']['id'])) : null ); ?></p>
 <p>Project Comments: <strong><?php echo (!$smartFormProject['SmartFormProject']['comments'] ? 'None' : $smartFormProject['SmartFormProject']['comments']); ?></strong></p>
 <p>&nbsp;</p>
-<p><?php echo $this->Html->link('Edit', array('action' => 'edit', $smartFormProject['SmartFormProject']['id'])) . ' | ' . $this->Html->link('Back', array('action' => 'active')); ?></p>
+<p><?php echo $this->Html->link('Edit', array('action' => 'edit', $smartFormProject['SmartFormProject']['id'])) . ' | ' . $this->Html->link('Invoice', array('action' => 'invoice', $smartFormProject['SmartFormProject']['id'])) . ' | ' . $this->Html->link('Back', array('action' => 'active')); ?></p>
 <p>&nbsp;</p>

--- a/app/View/Users/index.ctp
+++ b/app/View/Users/index.ctp
@@ -46,7 +46,22 @@
 				unset($letter);
 			?>
 		</ul>
-		<p><?php echo $this->Html->link("(See All Letters in Queue)",array('controller' => 'Letters', 'action' => 'active')); ?></p>
+		<p><?php echo $this->Html->link("(See All Letters in Queue)",array('controller' => 'Letters', 'action' => 'active', 'letter')); ?></p>
+	<?php
+		endif;
+	?>
+	<?php
+	if($stamps): ?>
+		<h3>My Active Stamp Requests:</h3>
+		<ul>
+			<?php foreach($stamps as $stamp): ?>
+				<li><?php echo $this->Html->link($stamp['Member']['full_name'] . ' (New: ' . $stamp['Letter']['new_templates'] . ', Revised: ' . $stamp['Letter']['revised_templates'] . '), Target Date: ' . $stamp['Letter']['target_date'], array('controller' => 'Letters', 'action' => 'view', $stamp['Letter']['id'])); ?></li>
+			<?php
+				endforeach;
+				unset($stamp);
+			?>
+		</ul>
+		<p><?php echo $this->Html->link("(See All Stamps in Queue)",array('controller' => 'Letters', 'action' => 'active', 'stamp')); ?></p>
 	<?php
 		endif;
 	?>

--- a/app/View/Users/index.ctp
+++ b/app/View/Users/index.ctp
@@ -46,7 +46,7 @@
 				unset($letter);
 			?>
 		</ul>
-		<p><?php echo $this->Html->link("**(See All Letters in Queue)**",array('controller' => 'Letters', 'action' => 'active')); ?></p>
+		<p><?php echo $this->Html->link("(See All Letters in Queue)",array('controller' => 'Letters', 'action' => 'active')); ?></p>
 	<?php
 		endif;
 	?>
@@ -62,7 +62,7 @@
 				unset($smartFormProject);
 			?>
 		</ul>
-		<p><?php echo $this->Html->link("**(See All Projects in Queue)**",array('controller' => 'SmartFormProjects', 'action' => 'active')); ?></p>
+		<p><?php echo $this->Html->link("(See All Projects in Queue)",array('controller' => 'SmartFormProjects', 'action' => 'active')); ?></p>
 	<?php
 		endif;
 	?>

--- a/app/View/Users/index.ctp
+++ b/app/View/Users/index.ctp
@@ -3,35 +3,67 @@
 <section>
 	<h3><?php echo 'Welcome ' . $this->Session->read('Auth.User.first_name') . '!<br />'; ?></h3>
 	<p>&nbsp;</p>
-	<?php if ($members) { ?>
-	<aside>
-	<h3>My Member Institutions:</h3>
+	<?php	
+		/****************************************************************************
+		 * 2015-10-28 OB: Commenting out My Member Institutions section (in V and C).
+		 * "Go-Live" tracking is no longer implemented in Support Portal, and the 
+		 * "My Member Institutions" list just gets longer and longer. I'm removing
+		 * it for the new release.
+		 **************************************************************************** 
+			if ($members) { ?>
+			<aside>
+			<h3>My Member Institutions:</h3>
+			<?php
+				foreach ($members as $member): 
+					echo '<p>' . $this->Html->link($member['Member']['full_name'], array('controller' => 'members', 'action' => 'view', $member['Member']['id'])) . '</p>';
+				endforeach;
+				unset($member);
+				} ?>
+			</aside>
+			<?php if($user['Committee']): ?>
+			<aside class="collapse">	
+			<h3>My Enrolling Committees:</h3>
+			<?php for($i = 0; $i < count($enrolling_committees); $i++): ?>
+				<p><?php echo $this->Html->link($enrolling_committees[$i][0]['Member']['full_name'] . ': ' . $user['Committee'][$i]['board_type'] . ' - Go Live Date: ' . $user['Committee'][$i]['go_live_date'], array('controller' => 'members', 'action' => 'view', $user['Committee'][$i]['member_id'])); ?></p>
+			<?php
+				endfor;
+				endif;
+			</aside>
+		
+		***************************************************************************
+		*/
+	?>
+
+	<?php 
+	// Populate list of active letter requests that user is working on.
+	if($letters): ?>
+		<h3>My Active Letter Requests:</h3>
+		<ul>
+			<?php foreach($letters as $letter): ?>
+				<li><?php echo $this->Html->link($letter['Member']['full_name'] . ' (New: ' . $letter['Letter']['new_templates'] . ', Revised: ' . $letter['Letter']['revised_templates'] . '), Target Date: ' . $letter['Letter']['target_date'], array('controller' => 'Letters', 'action' => 'view', $letter['Letter']['id'])); ?></li>
+			<?php
+				endforeach;
+				unset($letter);
+			?>
+		</ul>
+		<p><?php echo $this->Html->link("**(See All Letters in Queue)**",array('controller' => 'Letters', 'action' => 'active')); ?></p>
 	<?php
-		foreach ($members as $member): 
-			echo '<p>' . $this->Html->link($member['Member']['full_name'], array('controller' => 'members', 'action' => 'view', $member['Member']['id'])) . '</p>';
-		endforeach;
-		unset($member);
-		} ?>
-	</aside>
-	<?php if($user['Committee']): ?>
-	<aside class="collapse">	
-	<h3>My Enrolling Committees:</h3>
-	<?php for($i = 0; $i < count($enrolling_committees); $i++): ?>
-		<p><?php echo $this->Html->link($enrolling_committees[$i][0]['Member']['full_name'] . ': ' . $user['Committee'][$i]['board_type'] . ' - Go Live Date: ' . $user['Committee'][$i]['go_live_date'], array('controller' => 'members', 'action' => 'view', $user['Committee'][$i]['member_id'])); ?></p>
-	<?php
-		endfor;
 		endif;
 	?>
-	</aside>
-	<?php if($smartForms): ?>
-	<aside class="collapse">
-	<h3>My Smart Forms:</h3>
-	<?php foreach($smartForms as $smartForm): ?>
-		<p><?php echo $this->Html->link($smartForm['SmartForm']['sf_domain'] . ', ' . $smartForm['Member']['full_name'] . ': Launch Date: ' . $smartForm['SmartForm']['launch_date'], array('controller' => 'members', 'action' => 'view', $smartForm['Member']['id'])); ?></p>
 	<?php
-		endforeach;
-		unset($smartForm);
+	// Populate list of active smart form projects that user is working on.
+	if($smartFormProjects): ?>
+		<h3>My Active Smart Form Projects:</h3>
+		<ul>
+			<?php foreach($smartFormProjects as $smartFormProject): ?>
+				<li><?php echo $this->Html->link($smartFormProject['Member']['full_name'] . ' - ' . $smartFormProject['SmartForm']['name'], array('controller' => 'SmartFormProjects', 'action' => 'view', $smartFormProject['SmartFormProject']['id'])); ?></li>
+			<?php
+				endforeach;
+				unset($smartFormProject);
+			?>
+		</ul>
+		<p><?php echo $this->Html->link("**(See All Projects in Queue)**",array('controller' => 'SmartFormProjects', 'action' => 'active')); ?></p>
+	<?php
 		endif;
 	?>
-	</aside>
 </section>

--- a/app/webroot/js/irbnet_admin.js
+++ b/app/webroot/js/irbnet_admin.js
@@ -43,7 +43,7 @@ $(document).ready(function()
  ****************************************************************************
  */ 
 	//delete or retire popup on Member and Admin View page
-	$(function(deleteRetirePopup) {
+	$(function deleteRetirePopup() {
 		$('#deleteRetirePopup').dialog({
 			autoOpen: false,
 			height: 'auto',
@@ -62,7 +62,7 @@ $(document).ready(function()
 	});
 	
 	//delete popup on Member View page
-	$(function(deletePopup) {
+	$(function deletePopup() {
 		$('#deletePopup').dialog({
 			autoOpen: false,
 			height: 'auto',
@@ -85,7 +85,7 @@ $(document).ready(function()
  ****************************************************************************
  */ 
 	//delete or retire popup on Member or Admin View page
-	$(function(unRetirePopup) {
+	$(function unRetirePopup() {
 		$('#unRetirePopup').dialog({
 			autoOpen: false,
 			height: 'auto',
@@ -111,7 +111,7 @@ $(document).ready(function()
  * the result to the MembersController.
  ****************************************************************************
  */ 
-	$(function(orgSearch) {
+	$(function orgSearch() {
 		$("#orgSearchBox").dialog({
 			autoOpen: false,
 			width: 400,
@@ -149,7 +149,7 @@ $(document).ready(function()
  * the result to the AdminsController.
  ****************************************************************************
  */ 
-	$(function(adminSearch) {
+	$(function adminSearch() {
 		$("#adminSearchBox").dialog({
 			autoOpen: false,
 			height: 'auto',

--- a/app/webroot/js/irbnet_admin.js
+++ b/app/webroot/js/irbnet_admin.js
@@ -42,8 +42,8 @@ $(document).ready(function()
  * described in the View (e.g., View/Admins/view.
  ****************************************************************************
  */ 
-	//delete or retire popup on Member or Admin View page
-	$(function(deleteRetire) {
+	//delete or retire popup on Member and Admin View page
+	$(function(deleteRetirePopup) {
 		$('#deleteRetirePopup').dialog({
 			autoOpen: false,
 			height: 'auto',
@@ -60,13 +60,32 @@ $(document).ready(function()
 			$('#deleteRetirePopup').dialog('open');
 		});
 	});
+	
+	//delete popup on Member View page
+	$(function(deletePopup) {
+		$('#deletePopup').dialog({
+			autoOpen: false,
+			height: 'auto',
+			width: 400,
+			modal: true,
+			buttons: {
+				Cancel: function() {
+					$(this).dialog('close');
+				}
+			}
+		});
+
+		$('#deleteLink').on('click', function() {
+			$('#deletePopup').dialog('open');
+		});
+	});
 /****************************************************************************
  * UN-RETIRE AN ADMIN OR MEMBER
  * 
  ****************************************************************************
  */ 
 	//delete or retire popup on Member or Admin View page
-	$(function(unRetire) {
+	$(function(unRetirePopup) {
 		$('#unRetirePopup').dialog({
 			autoOpen: false,
 			height: 'auto',

--- a/app/webroot/js/irbnet_admin.js
+++ b/app/webroot/js/irbnet_admin.js
@@ -35,12 +35,11 @@ $(document).ready(function()
 			$('#retiredAdminsList').dialog('open');
 		});
 	});
-/****************************************************************************
+/**
  * RETIRE AN ADMIN OR MEMBER
  * When a user clicks the delete or retire button on a "view" View,
  * then it triggers this function. On click, the function opens a dialog box 
  * described in the View (e.g., View/Admins/view.
- ****************************************************************************
  */ 
 	//delete or retire popup on Member and Admin View page
 	$(function deleteRetirePopup() {
@@ -79,10 +78,9 @@ $(document).ready(function()
 			$('#deletePopup').dialog('open');
 		});
 	});
-/****************************************************************************
+/**
  * UN-RETIRE AN ADMIN OR MEMBER
  * 
- ****************************************************************************
  */ 
 	//delete or retire popup on Member or Admin View page
 	$(function unRetirePopup() {
@@ -102,14 +100,13 @@ $(document).ready(function()
 			$('#unRetirePopup').dialog('open');
 		});
 	});
-/****************************************************************************
+/**
  * ORGANIZATION SEARCH
  * When a user clicks the Members > Search button in the navbar
  * (view/elements/nav.ctp), then that triggers this function. 
  *
  * The javascript opens a search console with a plain-text field and submits
  * the result to the MembersController.
- ****************************************************************************
  */ 
 	$(function orgSearch() {
 		$("#orgSearchBox").dialog({
@@ -140,14 +137,13 @@ $(document).ready(function()
 		});
 	});
 
-/****************************************************************************
+/**
  * ADMINISTRATOR SEARCH
  * When a user clicks the Administrators > Search button in the navbar
  * (view/elements/nav.ctp), then that triggers this function. 
  *
  * The javascript opens a search console with a plain-text field and submits
  * the result to the AdminsController.
- ****************************************************************************
  */ 
 	$(function adminSearch() {
 		$("#adminSearchBox").dialog({
@@ -308,12 +304,19 @@ function activateMemberDropdown()
     }
     memberName.val(0);
 }
-
-//populates the "Submitted By" dropdown with a list of org admins
+/**
+ * RETRIEVE AN ADMIN LIST FOR NEW LETTERS AND STAMPS
+ * Gets a list of admins at a specific institution for the "Submitted By" field
+ * when creating a new letter or stamp request. The javascript function detects
+ * if user selects a member, then sends an AJAX request to server based on the 
+ * member id. This function then retrieves the admins associated with that member
+ * id.
+ */ 
 function activateSubmittedByDropdown()
 {
+	// get the member id from the member name field
 	var memberId = document.getElementById("member_name").value;
-	
+	// send member id as get request to list_admin function in LettersController
 	$.ajax({
 		url: 'list_admin',
 		type: 'GET',
@@ -324,6 +327,7 @@ function activateSubmittedByDropdown()
 			alert('Did not work');
 		},
 		success: function(data){
+			// populate submitter name menu with result
 			$("#submitter_name").html(data);
 		}
 	});

--- a/app/webroot/js/irbnet_admin.js
+++ b/app/webroot/js/irbnet_admin.js
@@ -35,9 +35,15 @@ $(document).ready(function()
 			$('#retiredAdminsList').dialog('open');
 		});
 	});
-
+/****************************************************************************
+ * RETIRE AN ADMIN OR MEMBER
+ * When a user clicks the delete or retire button on a "view" View,
+ * then it triggers this function. On click, the function opens a dialog box 
+ * described in the View (e.g., View/Admins/view.
+ ****************************************************************************
+ */ 
 	//delete or retire popup on Member or Admin View page
-	$(function() {
+	$(function(deleteRetire) {
 		$('#deleteRetirePopup').dialog({
 			autoOpen: false,
 			height: 'auto',
@@ -54,9 +60,39 @@ $(document).ready(function()
 			$('#deleteRetirePopup').dialog('open');
 		});
 	});
+/****************************************************************************
+ * UN-RETIRE AN ADMIN OR MEMBER
+ * 
+ ****************************************************************************
+ */ 
+	//delete or retire popup on Member or Admin View page
+	$(function(unRetire) {
+		$('#unRetirePopup').dialog({
+			autoOpen: false,
+			height: 'auto',
+			width: 400,
+			modal: true,
+			buttons: {
+				Cancel: function() {
+					$(this).dialog('close');
+				}
+			}
+		});
 
-	//organization search box
-	$(function() {
+		$('#unRetireLink').on('click', function() {
+			$('#unRetirePopup').dialog('open');
+		});
+	});
+/****************************************************************************
+ * ORGANIZATION SEARCH
+ * When a user clicks the Members > Search button in the navbar
+ * (view/elements/nav.ctp), then that triggers this function. 
+ *
+ * The javascript opens a search console with a plain-text field and submits
+ * the result to the MembersController.
+ ****************************************************************************
+ */ 
+	$(function(orgSearch) {
 		$("#orgSearchBox").dialog({
 			autoOpen: false,
 			width: 400,
@@ -85,8 +121,16 @@ $(document).ready(function()
 		});
 	});
 
-	//admin search box
-	$(function() {
+/****************************************************************************
+ * ADMINISTRATOR SEARCH
+ * When a user clicks the Administrators > Search button in the navbar
+ * (view/elements/nav.ctp), then that triggers this function. 
+ *
+ * The javascript opens a search console with a plain-text field and submits
+ * the result to the AdminsController.
+ ****************************************************************************
+ */ 
+	$(function(adminSearch) {
 		$("#adminSearchBox").dialog({
 			autoOpen: false,
 			height: 'auto',


### PR DESCRIPTION
Changes include:
**More functions now commented**
I have made some effort to add comments describing each function. In some cases, these functions are self-explanatory, but it should help other contributors from the team join the project.

**Home page tracks active letter requests, active stamp requests, and active smart form requests.**
When you log in, the home page will now have a bullet point list of all active letter requests, active stamp requests, and active smart form requests that you are working on.

**Stamps can now be tracked alongside Letters**

The Wizards tab of the nav bar will now have pages dedicated to "Letters and Stamps." These work in much the same way as they did when they were simply for letters, but they will now separate requests by "Type," which is a new field that you will see when adding or editing a request.  

Your claimed stamps will also now appear on the home page under the header "Your Active Stamp Requests." Clicking the link to see all stamp requests will take you to a filtered Active Letters and Stamps page.

**Members with Stamping Tools has been added as a List**  

The Lists tab of the nav bar will now have a list that says "Stamping Tools." This list pulls from the members for which a stamp request exists. This means that once a member has contracted for stamping tools, then you should add the request to the Support Portal as soon as possible.

**Administrators and Members can now be "un-retired."**

Previously, if an administrator or member had been marked as retired in the Support Portal, then it was only possible to undo the action from the back end. This has been reworked so that you may now reactivate the admin or member in the event of accidental "retirement."  

The reactivate icon looks like an arrow pointing in a clockwise circle.  

**When a Member is retired, then Support will be notified.**

If a Member has been marked as retired, then an email will now be sent to the Support inbox. The email will contain a link to the retired member's page, so that the action can be more easily un-done.

**It is now harder to delete Members from the Support Portal.**

I have changed the deletion process so that Members can only be deleted by users within 21 days of the Member being added to the Support Portal. After that point, you will have to contact a Site Admin (me). "Retire" is now the preferred process for removing members from Support Portal tracking. Deletion should be reserved for instances in which you not only want the member to no longer be tracked, but also remove them (and any corresponding smart forms, admins, and letters) from the site altogether.  

The delete icon looks like a trash can on the Member's detail page.  

**You can now use the Support Portal to create Smart Form Project scope descriptions to send to Andy.**

The Support Portal can now fill in some of the fields and give you a neatly formatted template to work with. The major advantage of this change is that the Support Portal will now give you a formatted list of all previous Smart Form projects from the current and previous year (if those projects have been logged in the Support Portal).

Andy has requested that Wizards developers still tally the number of new/revised steps, values, and fillins. This must still be done in the email - the template will not fill this in for you.

To use the scope page, take the following steps:
1.  Click the Wizards > Active section of the navigation bar
2.  On the far right of the Active Projects table, there is a column called "Actions"
3.  Click the Envelope icon in the Actions column
4.  Copy the scope template into your email
5.  Fill in the number of new steps, values, and fillins
6.  Send to Andy.
